### PR TITLE
feat: add sensitive content setting

### DIFF
--- a/Nagram/SettingsUI/BUILD
+++ b/Nagram/SettingsUI/BUILD
@@ -18,6 +18,7 @@ swift_library(
         "//submodules/ItemListUI:ItemListUI",
         "//submodules/PresentationDataUtils:PresentationDataUtils",
         "//submodules/AccountContext:AccountContext",
+        "//submodules/TelegramCore:TelegramCore",
         "//submodules/TelegramUIPreferences:TelegramUIPreferences",
         "//Nagram/Settings:NagramSettings",
         "//Nagram/Strings:NagramStrings",
@@ -25,6 +26,7 @@ swift_library(
         # MARK: NAGRAM — 贴纸尺寸滑杆(SliderComponent,复刻省电模式粗轨道)
         "//submodules/AsyncDisplayKit",
         "//submodules/ComponentFlow",
+        "//submodules/TelegramUI/Components/FaceScanScreen",
         "//submodules/TelegramUI/Components/SliderComponent",
     ],
     visibility = [

--- a/Nagram/SettingsUI/NagramSettingsController.swift
+++ b/Nagram/SettingsUI/NagramSettingsController.swift
@@ -1,12 +1,14 @@
-import Foundation
-import Display
-import SwiftSignalKit
-import TelegramPresentationData
-import ItemListUI
-import PresentationDataUtils
 import AccountContext
+import Display
+import FaceScanScreen
+import Foundation
+import ItemListUI
 import NagramSettings
 import NagramStrings
+import PresentationDataUtils
+import SwiftSignalKit
+import TelegramCore
+import TelegramPresentationData
 import TelegramUIPreferences
 
 // MARK: NAGRAM — 增强设置页 UI。
@@ -33,7 +35,7 @@ private enum NagramTab: Int32, CaseIterable {
 // 行类型:开关 / 单选(disclosure + ActionSheet) / 行内滑杆。
 private enum NagramRow {
     case toggle(titleKey: String, get: () -> Bool, set: (Bool) -> Void)
-    case toggleWithEnabled(titleKey: String, get: () -> Bool, set: (Bool) -> Void, enabled: () -> Bool)
+    case toggleWithEnabled(titleKey: String, get: () -> Bool, set: (Bool) -> Void, enabled: () -> Bool, enableInteractiveChanges: Bool)
     case choice(titleKey: String, prefix: String, options: [String], current: () -> String, set: (String) -> Void)
     case slider(minValue: Int32, maxValue: Int32, get: () -> Int32, set: (Int32) -> Void)
     case navigation(titleKey: String, action: () -> Void)
@@ -46,20 +48,32 @@ private struct NagramGroup {
     let rows: [NagramRow]
 }
 
-private func nagramGroups(hideCalls: @escaping () -> Bool, setHideCalls: @escaping (Bool) -> Void, messageMenuAction: @escaping () -> Void) -> [NagramGroup] {
+private func nagramGroups(
+    hideCalls: @escaping () -> Bool,
+    setHideCalls: @escaping (Bool) -> Void,
+    sensitiveContentConfiguration: @escaping () -> ContentSettingsConfiguration?,
+    setSensitiveContentEnabled: @escaping (Bool) -> Void,
+    messageMenuAction: @escaping () -> Void
+) -> [NagramGroup] {
     let tabBarSubitemEnabled: () -> Bool = {
         return !NagramSettings.shared.hideTabBar
+    }
+    let sensitiveContentEnabled: () -> Bool = {
+        return sensitiveContentConfiguration()?.sensitiveContentEnabled ?? false
+    }
+    let sensitiveContentCanAdjust: () -> Bool = {
+        return sensitiveContentConfiguration()?.canAdjustSensitiveContent ?? false
     }
     return [
         // 通用
         NagramGroup(tab: .general, headerKey: "Nagram.Section.Interface", footerKey: nil, rows: [
             .toggle(titleKey: "Nagram.HideTabBar", get: { NagramSettings.shared.hideTabBar }, set: { NagramSettings.shared.hideTabBar = $0 }),
-            .toggleWithEnabled(titleKey: "Nagram.HideTabBarCalls", get: hideCalls, set: setHideCalls, enabled: tabBarSubitemEnabled),
-            .toggleWithEnabled(titleKey: "Nagram.HideTabBarContacts", get: { NagramSettings.shared.hideTabBarContacts }, set: { NagramSettings.shared.hideTabBarContacts = $0 }, enabled: tabBarSubitemEnabled),
-            .toggleWithEnabled(titleKey: "Nagram.HideTabBarChatList", get: { NagramSettings.shared.hideTabBarChats }, set: { NagramSettings.shared.hideTabBarChats = $0 }, enabled: tabBarSubitemEnabled),
-            .toggleWithEnabled(titleKey: "Nagram.HideTabBarSettings", get: { NagramSettings.shared.hideTabBarSettings }, set: { NagramSettings.shared.hideTabBarSettings = $0 }, enabled: tabBarSubitemEnabled),
-            .toggleWithEnabled(titleKey: "Nagram.ShowTabBarSearch", get: { NagramSettings.shared.showTabBarSearch }, set: { NagramSettings.shared.showTabBarSearch = $0 }, enabled: tabBarSubitemEnabled),
-            .toggleWithEnabled(titleKey: "Nagram.WideTabBar", get: { NagramSettings.shared.wideTabBar }, set: { NagramSettings.shared.wideTabBar = $0 }, enabled: tabBarSubitemEnabled),
+            .toggleWithEnabled(titleKey: "Nagram.HideTabBarCalls", get: hideCalls, set: setHideCalls, enabled: tabBarSubitemEnabled, enableInteractiveChanges: true),
+            .toggleWithEnabled(titleKey: "Nagram.HideTabBarContacts", get: { NagramSettings.shared.hideTabBarContacts }, set: { NagramSettings.shared.hideTabBarContacts = $0 }, enabled: tabBarSubitemEnabled, enableInteractiveChanges: true),
+            .toggleWithEnabled(titleKey: "Nagram.HideTabBarChatList", get: { NagramSettings.shared.hideTabBarChats }, set: { NagramSettings.shared.hideTabBarChats = $0 }, enabled: tabBarSubitemEnabled, enableInteractiveChanges: true),
+            .toggleWithEnabled(titleKey: "Nagram.HideTabBarSettings", get: { NagramSettings.shared.hideTabBarSettings }, set: { NagramSettings.shared.hideTabBarSettings = $0 }, enabled: tabBarSubitemEnabled, enableInteractiveChanges: true),
+            .toggleWithEnabled(titleKey: "Nagram.ShowTabBarSearch", get: { NagramSettings.shared.showTabBarSearch }, set: { NagramSettings.shared.showTabBarSearch = $0 }, enabled: tabBarSubitemEnabled, enableInteractiveChanges: true),
+            .toggleWithEnabled(titleKey: "Nagram.WideTabBar", get: { NagramSettings.shared.wideTabBar }, set: { NagramSettings.shared.wideTabBar = $0 }, enabled: tabBarSubitemEnabled, enableInteractiveChanges: true),
             .toggle(titleKey: "Nagram.HideStories", get: { NagramSettings.shared.hideStories }, set: { NagramSettings.shared.hideStories = $0 }),
         ]),
         NagramGroup(tab: .general, headerKey: "Nagram.Section.Camera", footerKey: "Nagram.Section.Camera.Footer", rows: [
@@ -105,7 +119,10 @@ private func nagramGroups(hideCalls: @escaping () -> Bool, setHideCalls: @escapi
         NagramGroup(tab: .other, headerKey: "Nagram.Section.Calls", footerKey: nil, rows: [
             .toggle(titleKey: "Nagram.ConfirmCalls", get: { NagramSettings.shared.confirmCalls }, set: { NagramSettings.shared.confirmCalls = $0 }),
         ]),
-        NagramGroup(tab: .other, headerKey: "Nagram.Section.Privacy", footerKey: "Nagram.ForceCopy.Footer", rows: [
+        NagramGroup(tab: .other, headerKey: "Nagram.Section.Privacy", footerKey: "Nagram.DisableFiltering.Footer", rows: [
+            .toggleWithEnabled(titleKey: "Nagram.DisableFiltering", get: sensitiveContentEnabled, set: setSensitiveContentEnabled, enabled: sensitiveContentCanAdjust, enableInteractiveChanges: false),
+        ]),
+        NagramGroup(tab: .other, headerKey: nil, footerKey: "Nagram.ForceCopy.Footer", rows: [
             .toggle(titleKey: "Nagram.ForceCopy", get: { NagramSettings.shared.forceCopyEnabled }, set: { NagramSettings.shared.forceCopyEnabled = $0 }),
         ]),
     ]
@@ -124,7 +141,7 @@ private final class NagramSettingsArguments {
 
 private enum NagramSettingsEntry: ItemListNodeEntry {
     case header(stableId: Int32, section: Int32, text: String)
-    case toggle(stableId: Int32, section: Int32, title: String, value: Bool, enabled: Bool, index: Int)
+    case toggle(stableId: Int32, section: Int32, title: String, value: Bool, enabled: Bool, enableInteractiveChanges: Bool, index: Int)
     case disclosure(stableId: Int32, section: Int32, title: String, label: String, index: Int)
     case slider(stableId: Int32, section: Int32, minValue: Int32, maxValue: Int32, value: Int32, index: Int)
     case footer(stableId: Int32, section: Int32, text: String)
@@ -132,7 +149,7 @@ private enum NagramSettingsEntry: ItemListNodeEntry {
     var section: ItemListSectionId {
         switch self {
         case let .header(_, section, _): return section
-        case let .toggle(_, section, _, _, _, _): return section
+        case let .toggle(_, section, _, _, _, _, _): return section
         case let .disclosure(_, section, _, _, _): return section
         case let .slider(_, section, _, _, _, _): return section
         case let .footer(_, section, _): return section
@@ -142,7 +159,7 @@ private enum NagramSettingsEntry: ItemListNodeEntry {
     var stableId: Int32 {
         switch self {
         case let .header(stableId, _, _): return stableId
-        case let .toggle(stableId, _, _, _, _, _): return stableId
+        case let .toggle(stableId, _, _, _, _, _, _): return stableId
         case let .disclosure(stableId, _, _, _, _): return stableId
         case let .slider(stableId, _, _, _, _, _): return stableId
         case let .footer(stableId, _, _): return stableId
@@ -154,8 +171,8 @@ private enum NagramSettingsEntry: ItemListNodeEntry {
         case let .header(lId, lSec, lText):
             if case let .header(rId, rSec, rText) = rhs { return lId == rId && lSec == rSec && lText == rText }
             return false
-        case let .toggle(lId, lSec, lTitle, lValue, lEnabled, lIndex):
-            if case let .toggle(rId, rSec, rTitle, rValue, rEnabled, rIndex) = rhs { return lId == rId && lSec == rSec && lTitle == rTitle && lValue == rValue && lEnabled == rEnabled && lIndex == rIndex }
+        case let .toggle(lId, lSec, lTitle, lValue, lEnabled, lEnableInteractiveChanges, lIndex):
+            if case let .toggle(rId, rSec, rTitle, rValue, rEnabled, rEnableInteractiveChanges, rIndex) = rhs { return lId == rId && lSec == rSec && lTitle == rTitle && lValue == rValue && lEnabled == rEnabled && lEnableInteractiveChanges == rEnableInteractiveChanges && lIndex == rIndex }
             return false
         case let .disclosure(lId, lSec, lTitle, lLabel, lIndex):
             if case let .disclosure(rId, rSec, rTitle, rLabel, rIndex) = rhs { return lId == rId && lSec == rSec && lTitle == rTitle && lLabel == rLabel && lIndex == rIndex }
@@ -178,8 +195,8 @@ private enum NagramSettingsEntry: ItemListNodeEntry {
         switch self {
         case let .header(_, section, text):
             return ItemListSectionHeaderItem(presentationData: presentationData, text: text, sectionId: section)
-        case let .toggle(_, section, title, value, enabled, index):
-            return ItemListSwitchItem(presentationData: presentationData, systemStyle: .glass, title: title, value: value, enabled: enabled, sectionId: section, style: .blocks, updated: { value in
+        case let .toggle(_, section, title, value, enabled, enableInteractiveChanges, index):
+            return ItemListSwitchItem(presentationData: presentationData, systemStyle: .glass, title: title, value: value, enableInteractiveChanges: enableInteractiveChanges, enabled: enabled, sectionId: section, style: .blocks, updated: { value in
                 arguments.toggle(index, value)
             })
         case let .disclosure(_, section, title, label, index):
@@ -198,6 +215,15 @@ private enum NagramSettingsEntry: ItemListNodeEntry {
 
 public func nagramSettingsController(context: AccountContext) -> ViewController {
     var currentShowCallsTab = CallListSettings.defaultSettings.showTab
+    var currentContentSettingsConfiguration: ContentSettingsConfiguration?
+    let contentSettingsConfigurationPromise = Promise<ContentSettingsConfiguration?>()
+    contentSettingsConfigurationPromise.set(.single(nil)
+    |> then(contentSettingsConfiguration(network: context.account.network)
+    |> map(Optional.init)))
+
+    let updateSensitiveContentDisposable = MetaDisposable()
+    var presentControllerImpl: ((ViewController, ViewControllerPresentationArguments?) -> Void)?
+    var presentAgeVerificationImpl: ((@escaping () -> Void) -> Void)?
     var pushControllerImpl: ((ViewController) -> Void)?
     let groups = nagramGroups(hideCalls: {
         return !currentShowCallsTab
@@ -206,6 +232,33 @@ public func nagramSettingsController(context: AccountContext) -> ViewController 
         let _ = updateCallListSettingsInteractively(accountManager: context.sharedContext.accountManager, {
             $0.withUpdatedShowTab(!hidden)
         }).startStandalone()
+    }, sensitiveContentConfiguration: {
+        return currentContentSettingsConfiguration
+    }, setSensitiveContentEnabled: { value in
+        let update = {
+            if var settings = currentContentSettingsConfiguration {
+                settings.sensitiveContentEnabled = value
+                currentContentSettingsConfiguration = settings
+                contentSettingsConfigurationPromise.set(.single(settings))
+            }
+            updateSensitiveContentDisposable.set(updateRemoteContentSettingsConfiguration(postbox: context.account.postbox, network: context.account.network, sensitiveContentEnabled: value).start())
+        }
+        if value {
+            if requireAgeVerification(context: context) {
+                presentAgeVerificationImpl?(update)
+            } else {
+                let presentationData = context.sharedContext.currentPresentationData.with { $0 }
+                let alertController = textAlertController(context: context, title: presentationData.strings.SensitiveContent_Enable_Title, text: presentationData.strings.SensitiveContent_Enable_Text, actions: [
+                    TextAlertAction(type: .genericAction, title: presentationData.strings.Common_Cancel, action: {}),
+                    TextAlertAction(type: .defaultAction, title: presentationData.strings.SensitiveContent_Enable_Confirm, action: {
+                        update()
+                    })
+                ])
+                presentControllerImpl?(alertController, nil)
+            }
+        } else {
+            update()
+        }
     }, messageMenuAction: {
         pushControllerImpl?(nagramMessageMenuSettingsController(context: context))
     })
@@ -221,11 +274,9 @@ public func nagramSettingsController(context: AccountContext) -> ViewController 
         updatePromise.set(updateValue)
     }
 
-    var presentControllerImpl: ((ViewController, ViewControllerPresentationArguments?) -> Void)?
-
     let arguments = NagramSettingsArguments(toggle: { index, value in
         switch flatRows[index] {
-        case let .toggle(_, _, set), let .toggleWithEnabled(_, _, set, _):
+        case let .toggle(_, _, set), let .toggleWithEnabled(_, _, set, _, _):
             set(value)
             bump()
         default:
@@ -268,14 +319,16 @@ public func nagramSettingsController(context: AccountContext) -> ViewController 
         context.sharedContext.presentationData,
         tabPromise.get(),
         updatePromise.get(),
+        contentSettingsConfigurationPromise.get(),
         context.sharedContext.accountManager.sharedData(keys: [ApplicationSpecificSharedDataKeys.callListSettings])
         |> map { sharedData -> Bool in
             return sharedData.entries[ApplicationSpecificSharedDataKeys.callListSettings]?.get(CallListSettings.self)?.showTab ?? CallListSettings.defaultSettings.showTab
         }
     )
     |> deliverOnMainQueue
-    |> map { presentationData, selectedTab, _, showCallsTab -> (ItemListControllerState, (ItemListNodeState, Any)) in
+    |> map { presentationData, selectedTab, _, contentSettingsConfiguration, showCallsTab -> (ItemListControllerState, (ItemListNodeState, Any)) in
         currentShowCallsTab = showCallsTab
+        currentContentSettingsConfiguration = contentSettingsConfiguration
         let lang = presentationData.strings.baseLanguageCode
 
         // stableId 必须全局唯一且稳定:遍历所有 group 全局递增分配,当前 tab 只取子集。
@@ -301,9 +354,9 @@ public func nagramSettingsController(context: AccountContext) -> ViewController 
                 if isCurrent {
                     switch row {
                     case let .toggle(titleKey, get, _):
-                        entries.append(.toggle(stableId: rowStableId, section: sectionId, title: ngI18n(titleKey, lang), value: get(), enabled: true, index: rowIndex))
-                    case let .toggleWithEnabled(titleKey, get, _, enabled):
-                        entries.append(.toggle(stableId: rowStableId, section: sectionId, title: ngI18n(titleKey, lang), value: get(), enabled: enabled(), index: rowIndex))
+                        entries.append(.toggle(stableId: rowStableId, section: sectionId, title: ngI18n(titleKey, lang), value: get(), enabled: true, enableInteractiveChanges: true, index: rowIndex))
+                    case let .toggleWithEnabled(titleKey, get, _, enabled, enableInteractiveChanges):
+                        entries.append(.toggle(stableId: rowStableId, section: sectionId, title: ngI18n(titleKey, lang), value: get(), enabled: enabled(), enableInteractiveChanges: enableInteractiveChanges, index: rowIndex))
                     case let .choice(titleKey, prefix, _, current, _):
                         entries.append(.disclosure(stableId: rowStableId, section: sectionId, title: ngI18n(titleKey, lang), label: ngI18n("\(prefix).\(current())", lang), index: rowIndex))
                     case let .slider(minValue, maxValue, get, _):
@@ -327,6 +380,9 @@ public func nagramSettingsController(context: AccountContext) -> ViewController 
 
         return (controllerState, (listState, arguments))
     }
+    |> afterDisposed {
+        updateSensitiveContentDisposable.dispose()
+    }
 
     let controller = ItemListController(context: context, state: signal)
     controller.navigationPresentation = .default
@@ -335,6 +391,14 @@ public func nagramSettingsController(context: AccountContext) -> ViewController 
     }
     presentControllerImpl = { [weak controller] c, presentationArguments in
         controller?.present(c, in: .window(.root), with: presentationArguments)
+    }
+    presentAgeVerificationImpl = { [weak controller] update in
+        guard let controller else {
+            return
+        }
+        presentAgeVerification(context: context, parentController: controller, completion: {
+            update()
+        })
     }
     pushControllerImpl = { [weak controller] c in
         (controller?.navigationController as? NavigationController)?.pushViewController(c, animated: true)

--- a/Nagram/Strings/Strings/en.lproj/NagramLocalizable.strings
+++ b/Nagram/Strings/Strings/en.lproj/NagramLocalizable.strings
@@ -25,6 +25,8 @@
 "Nagram.DisableScrollToNextTopic" = "Disable Swipe to Next Topic";
 "Nagram.DisableGalleryCamera" = "Disable In-Gallery Camera";
 "Nagram.DisableGalleryCameraPreview" = "Disable Camera Preview";
+"Nagram.DisableFiltering" = "Disable Filtering";
+"Nagram.DisableFiltering.Footer" = "When available, show sensitive content instead of filtering it. This is an account setting synced by Telegram.";
 "Nagram.ForceCopy" = "Force Copy";
 "Nagram.ForceCopy.Footer" = "Allow copying message text even in chats with content protection (no copy / no forward) enabled.";
 "Nagram.MessageMenu" = "Message Menu";

--- a/Nagram/Strings/Strings/ja.lproj/NagramLocalizable.strings
+++ b/Nagram/Strings/Strings/ja.lproj/NagramLocalizable.strings
@@ -25,6 +25,8 @@
 "Nagram.DisableScrollToNextTopic" = "次のトピックへのスワイプを無効化";
 "Nagram.DisableGalleryCamera" = "ギャラリー内カメラを無効化";
 "Nagram.DisableGalleryCameraPreview" = "カメラプレビューを無効化";
+"Nagram.DisableFiltering" = "センシティブ内容のフィルターを無効化";
+"Nagram.DisableFiltering.Footer" = "利用可能な場合、センシティブな内容をフィルターで隠さずに表示します。この項目は Telegram で同期されるアカウント設定です。";
 "Nagram.ForceCopy" = "強制コピー";
 "Nagram.ForceCopy.Footer" = "コンテンツ保護（コピー/転送禁止）が有効なチャットでもメッセージ本文をコピーできるようにします。";
 "Nagram.MessageMenu" = "メッセージメニュー管理";

--- a/Nagram/Strings/Strings/zh-hans.lproj/NagramLocalizable.strings
+++ b/Nagram/Strings/Strings/zh-hans.lproj/NagramLocalizable.strings
@@ -25,6 +25,8 @@
 "Nagram.DisableScrollToNextTopic" = "禁止上滑到下一主题";
 "Nagram.DisableGalleryCamera" = "禁用图库内相机";
 "Nagram.DisableGalleryCameraPreview" = "禁用图库相机预览";
+"Nagram.DisableFiltering" = "关闭敏感内容过滤";
+"Nagram.DisableFiltering.Footer" = "可用时，显示敏感内容而不是过滤隐藏。此项是 Telegram 同步的账号设置。";
 "Nagram.ForceCopy" = "强制复制";
 "Nagram.ForceCopy.Footer" = "开启后，在设置了内容保护（禁止复制/转发）的对话中仍可复制消息文本。";
 "Nagram.MessageMenu" = "消息菜单管理";

--- a/Nagram/Strings/Strings/zh-hant.lproj/NagramLocalizable.strings
+++ b/Nagram/Strings/Strings/zh-hant.lproj/NagramLocalizable.strings
@@ -25,6 +25,8 @@
 "Nagram.DisableScrollToNextTopic" = "停用上滑至下一主題";
 "Nagram.DisableGalleryCamera" = "停用圖庫內相機";
 "Nagram.DisableGalleryCameraPreview" = "停用圖庫相機預覽";
+"Nagram.DisableFiltering" = "關閉敏感內容過濾";
+"Nagram.DisableFiltering.Footer" = "可用時，顯示敏感內容而不是過濾隱藏。此項是 Telegram 同步的帳號設定。";
 "Nagram.ForceCopy" = "強制複製";
 "Nagram.ForceCopy.Footer" = "開啟後，在設定了內容保護（禁止複製/轉發）的對話中仍可複製訊息文字。";
 "Nagram.MessageMenu" = "訊息選單管理";


### PR DESCRIPTION
## Summary
- Add a Nagram Privacy switch for Telegram account sensitive-content filtering.
- Reuse upstream content settings APIs, adult-content confirmation, and age-verification flow.
- Add localized labels and footer copy for en, zh-Hans, zh-Hant, and ja.

## Validation
- xcrun swiftc -parse Nagram/SettingsUI/NagramSettingsController.swift
- Full simulator build attempted, but the fresh jj workspace lacks expanded git submodules and Bazel stopped before Swift compilation at build-system/bazel-rules/apple_support.

Fixes #18