### PR TITLE
feat: implement pangu spacing

### DIFF
--- a/Nagram/Settings/NagramPangu.swift
+++ b/Nagram/Settings/NagramPangu.swift
@@ -1,0 +1,208 @@
+import Foundation
+
+public struct NagramPanguTransform: Equatable {
+    public let text: String
+    public let insertedUtf16Offsets: [Int]
+
+    public init(text: String, insertedUtf16Offsets: [Int]) {
+        self.text = text
+        self.insertedUtf16Offsets = insertedUtf16Offsets
+    }
+}
+
+public enum NagramPangu {
+    private static let protectedAttributeKeyNames: Set<String> = [
+        "Attribute__Monospace",
+        "Attribute__TextMention",
+        "Attribute__TextUrl",
+        "Attribute__Date",
+        "Attribute__CustomEmoji",
+        "Attribute__OriginalText",
+        "Attribute__Blockquote",
+        "Attribute__CollapsedBlockquote",
+    ]
+
+    public static func transform(_ text: String) -> NagramPanguTransform {
+        return self.transform(text, protectedUtf16Ranges: [])
+    }
+
+    public static func transform(_ text: String, protectedUtf16Ranges: [Range<Int>]) -> NagramPanguTransform {
+        guard text.count > 1 else {
+            return NagramPanguTransform(text: text, insertedUtf16Offsets: [])
+        }
+
+        let protectedUtf16Ranges = normalizedProtectedUtf16Ranges(protectedUtf16Ranges, textLength: text.utf16.count)
+        var result = String()
+        result.reserveCapacity(text.count)
+
+        var insertedUtf16Offsets: [Int] = []
+        var index = text.startIndex
+        while index < text.endIndex {
+            let current = text[index]
+            result.append(current)
+
+            let nextIndex = text.index(after: index)
+            if nextIndex < text.endIndex {
+                let next = text[nextIndex]
+                let nextUtf16Offset = nextIndex.utf16Offset(in: text)
+                if shouldInsertSpace(between: current, and: next) && !isProtectedInsertionOffset(nextUtf16Offset, ranges: protectedUtf16Ranges) {
+                    result.append(" ")
+                    insertedUtf16Offsets.append(nextUtf16Offset)
+                }
+            }
+
+            index = nextIndex
+        }
+
+        if insertedUtf16Offsets.isEmpty {
+            return NagramPanguTransform(text: text, insertedUtf16Offsets: [])
+        }
+        return NagramPanguTransform(text: result, insertedUtf16Offsets: insertedUtf16Offsets)
+    }
+
+    public static func transform(_ attributedText: NSAttributedString) -> NSAttributedString {
+        return self.transform(attributedText, protectedUtf16Ranges: self.protectedUtf16Ranges(attributedText))
+    }
+
+    public static func transform(_ attributedText: NSAttributedString, protectedUtf16Ranges: [Range<Int>]) -> NSAttributedString {
+        let transform = self.transform(attributedText.string, protectedUtf16Ranges: protectedUtf16Ranges)
+        guard !transform.insertedUtf16Offsets.isEmpty else {
+            return attributedText
+        }
+
+        let result = NSMutableAttributedString(attributedString: attributedText)
+        for (index, offset) in transform.insertedUtf16Offsets.enumerated() {
+            let insertionIndex = offset + index
+            result.insert(NSAttributedString(string: " ", attributes: self.insertedSpaceAttributes(in: result, at: insertionIndex)), at: insertionIndex)
+        }
+        return result
+    }
+
+    public static func transformRange(_ range: Range<Int>, insertedUtf16Offsets: [Int]) -> Range<Int> {
+        guard !insertedUtf16Offsets.isEmpty else {
+            return range
+        }
+
+        let lowerBound = range.lowerBound + insertedUtf16Offsets.filter { $0 <= range.lowerBound }.count
+        let upperBound = range.upperBound + insertedUtf16Offsets.filter { $0 < range.upperBound }.count
+        return lowerBound ..< max(lowerBound, upperBound)
+    }
+
+    private static func protectedUtf16Ranges(_ attributedText: NSAttributedString) -> [Range<Int>] {
+        var ranges: [Range<Int>] = []
+        attributedText.enumerateAttributes(in: NSRange(location: 0, length: attributedText.length), options: []) { attributes, range, _ in
+            guard attributes.contains(where: { self.isProtectedAttribute(key: $0.key, value: $0.value) }) else {
+                return
+            }
+            ranges.append(range.lowerBound ..< range.upperBound)
+        }
+        return ranges
+    }
+
+    private static func insertedSpaceAttributes(in attributedText: NSAttributedString, at index: Int) -> [NSAttributedString.Key: Any] {
+        var attributes: [NSAttributedString.Key: Any]
+        if index > 0 {
+            attributes = attributedText.attributes(at: index - 1, effectiveRange: nil)
+        } else if index < attributedText.length {
+            attributes = attributedText.attributes(at: index, effectiveRange: nil)
+        } else {
+            attributes = [:]
+        }
+        attributes = attributes.filter { !self.isProtectedAttribute(key: $0.key, value: $0.value) }
+        return attributes
+    }
+
+    private static func isProtectedAttribute(key: NSAttributedString.Key, value: Any) -> Bool {
+        if key.rawValue == "Attribute__Blockquote" {
+            return self.isCodeBlockQuoteAttribute(value)
+        }
+        return self.protectedAttributeKeyNames.contains(key.rawValue)
+    }
+
+    private static func isCodeBlockQuoteAttribute(_ value: Any) -> Bool {
+        for child in Mirror(reflecting: value).children {
+            if child.label == "kind" {
+                return String(describing: child.value).hasPrefix("code")
+            }
+        }
+        return false
+    }
+
+    private static func normalizedProtectedUtf16Ranges(_ ranges: [Range<Int>], textLength: Int) -> [Range<Int>] {
+        let ranges = ranges.compactMap { range -> Range<Int>? in
+            let lowerBound = max(0, min(textLength, range.lowerBound))
+            let upperBound = max(lowerBound, min(textLength, range.upperBound))
+            guard lowerBound < upperBound else {
+                return nil
+            }
+            return lowerBound ..< upperBound
+        }.sorted {
+            if $0.lowerBound == $1.lowerBound {
+                return $0.upperBound < $1.upperBound
+            }
+            return $0.lowerBound < $1.lowerBound
+        }
+
+        var merged: [Range<Int>] = []
+        for range in ranges {
+            if let last = merged.last, range.lowerBound <= last.upperBound {
+                merged[merged.count - 1] = last.lowerBound ..< max(last.upperBound, range.upperBound)
+            } else {
+                merged.append(range)
+            }
+        }
+        return merged
+    }
+
+    private static func isProtectedInsertionOffset(_ offset: Int, ranges: [Range<Int>]) -> Bool {
+        for range in ranges {
+            if offset <= range.lowerBound {
+                return false
+            }
+            if offset < range.upperBound {
+                return true
+            }
+        }
+        return false
+    }
+
+    private static func shouldInsertSpace(between left: Character, and right: Character) -> Bool {
+        if isWhitespace(left) || isWhitespace(right) {
+            return false
+        }
+
+        return (isCJK(left) && isWesternAlphanumeric(right)) || (isWesternAlphanumeric(left) && isCJK(right))
+    }
+
+    private static func isWhitespace(_ character: Character) -> Bool {
+        return character.unicodeScalars.allSatisfy { CharacterSet.whitespacesAndNewlines.contains($0) }
+    }
+
+    private static func isWesternAlphanumeric(_ character: Character) -> Bool {
+        guard character.unicodeScalars.count == 1, let scalar = character.unicodeScalars.first else {
+            return false
+        }
+        switch scalar.value {
+        case 0x30 ... 0x39, 0x41 ... 0x5A, 0x61 ... 0x7A:
+            return true
+        default:
+            return false
+        }
+    }
+
+    private static func isCJK(_ character: Character) -> Bool {
+        guard character.unicodeScalars.count == 1, let scalar = character.unicodeScalars.first else {
+            return false
+        }
+        switch scalar.value {
+        case 0x3040 ... 0x30FF,
+             0x3400 ... 0x4DBF,
+             0x4E00 ... 0x9FFF,
+             0xAC00 ... 0xD7AF,
+             0xF900 ... 0xFAFF:
+            return true
+        default:
+            return false
+        }
+    }
+}

--- a/Nagram/Settings/NagramSettings.swift
+++ b/Nagram/Settings/NagramSettings.swift
@@ -124,6 +124,15 @@ public final class NagramSettings {
     /// 回车键发送消息
     @NagramDefault("nagram.sendWithReturnKey", false)
     public var sendWithReturnKey: Bool
+    /// 发送时自动插入中英文空格
+    @NagramDefault("nagram.enablePanguOnSending", false)
+    public var enablePanguOnSending: Bool
+    /// 编辑时自动插入中英文空格
+    @NagramDefault("nagram.enablePanguOnEditing", false)
+    public var enablePanguOnEditing: Bool
+    /// 接收展示时自动插入中英文空格
+    @NagramDefault("nagram.enablePanguOnReceiving", false)
+    public var enablePanguOnReceiving: Bool
     /// 更宽的频道帖子
     @NagramDefault("nagram.wideChannelPosts", false)
     public var wideChannelPosts: Bool

--- a/Nagram/SettingsUI/NagramSettingsController.swift
+++ b/Nagram/SettingsUI/NagramSettingsController.swift
@@ -90,6 +90,11 @@ private func nagramGroups(
             .toggle(titleKey: "Nagram.HideReactions", get: { NagramSettings.shared.hideReactions }, set: { NagramSettings.shared.hideReactions = $0 }),
             .toggle(titleKey: "Nagram.HideChannelBottomButton", get: { NagramSettings.shared.hideChannelBottomButton }, set: { NagramSettings.shared.hideChannelBottomButton = $0 }),
         ]),
+        NagramGroup(tab: .chat, headerKey: "Nagram.Section.Pangu", footerKey: "Nagram.PanguInfo", rows: [
+            .toggle(titleKey: "Nagram.PanguOnReceiving", get: { NagramSettings.shared.enablePanguOnReceiving }, set: { NagramSettings.shared.enablePanguOnReceiving = $0 }),
+            .toggle(titleKey: "Nagram.PanguOnSending", get: { NagramSettings.shared.enablePanguOnSending }, set: { NagramSettings.shared.enablePanguOnSending = $0 }),
+            .toggle(titleKey: "Nagram.PanguOnEditing", get: { NagramSettings.shared.enablePanguOnEditing }, set: { NagramSettings.shared.enablePanguOnEditing = $0 }),
+        ]),
         NagramGroup(tab: .chat, headerKey: "Nagram.Section.MessageMenu", footerKey: nil, rows: [
             .navigation(titleKey: "Nagram.MessageMenu", action: messageMenuAction),
         ]),

--- a/Nagram/Strings/Strings/en.lproj/NagramLocalizable.strings
+++ b/Nagram/Strings/Strings/en.lproj/NagramLocalizable.strings
@@ -6,6 +6,7 @@
 "Nagram.Section.Camera" = "Camera";
 "Nagram.Section.Camera.Footer" = "Camera entry and live preview in the attachment menu.";
 "Nagram.Section.MessageDisplay" = "Message Display";
+"Nagram.Section.Pangu" = "Pangu Spacing";
 "Nagram.Section.MessageMenu" = "Message Menu";
 "Nagram.Section.Sending" = "Sending";
 "Nagram.Section.Gesture" = "Gestures";
@@ -13,9 +14,13 @@
 "Nagram.Section.Privacy" = "Privacy";
 
 "Nagram.SecondsInMessages" = "Show Seconds in Timestamps";
+"Nagram.PanguOnReceiving" = "Enable Pangu on Receiving";
+"Nagram.PanguInfo" = "Paranoid text spacing for good readability, automatically inserting spaces between CJK, half-width English, digits, and symbols.";
 "Nagram.HideReactions" = "Hide Reactions";
 "Nagram.DisableSendAsButton" = "Hide \"Send as Channel\" Button";
 "Nagram.SendWithReturnKey" = "Send with Return Key";
+"Nagram.PanguOnSending" = "Enable Pangu on Sending";
+"Nagram.PanguOnEditing" = "Enable Pangu on Editing";
 "Nagram.HideRecordingButton" = "Hide Voice Recording Button";
 "Nagram.UploadSpeedBoost" = "Upload Boost";
 "Nagram.Section.Network" = "Network Boost";

--- a/Nagram/Strings/Strings/ja.lproj/NagramLocalizable.strings
+++ b/Nagram/Strings/Strings/ja.lproj/NagramLocalizable.strings
@@ -6,6 +6,7 @@
 "Nagram.Section.Camera" = "カメラ";
 "Nagram.Section.Camera.Footer" = "添付メニュー内のカメラ入口とライブプレビュー。";
 "Nagram.Section.MessageDisplay" = "メッセージ表示";
+"Nagram.Section.Pangu" = "盤古の白";
 "Nagram.Section.MessageMenu" = "メッセージメニュー";
 "Nagram.Section.Sending" = "送信";
 "Nagram.Section.Gesture" = "ジェスチャ";
@@ -13,9 +14,13 @@
 "Nagram.Section.Privacy" = "プライバシー";
 
 "Nagram.SecondsInMessages" = "タイムスタンプに秒を表示";
+"Nagram.PanguOnReceiving" = "受信メッセージをPangu化";
+"Nagram.PanguInfo" = "文字を読みやすくするため、CJK（中国語、日本語、韓国語）、半角英数字、記号の間に自動でスペースを挿入します。";
 "Nagram.HideReactions" = "リアクションを非表示";
 "Nagram.DisableSendAsButton" = "「チャンネルとして送信」ボタンを非表示";
 "Nagram.SendWithReturnKey" = "Returnキーで送信";
+"Nagram.PanguOnSending" = "送信メッセージをPangu化";
+"Nagram.PanguOnEditing" = "編集メッセージをPangu化";
 "Nagram.HideRecordingButton" = "音声録音ボタンを非表示";
 "Nagram.UploadSpeedBoost" = "アップロード高速化";
 "Nagram.Section.Network" = "ネットワーク高速化";

--- a/Nagram/Strings/Strings/zh-hans.lproj/NagramLocalizable.strings
+++ b/Nagram/Strings/Strings/zh-hans.lproj/NagramLocalizable.strings
@@ -6,6 +6,7 @@
 "Nagram.Section.Camera" = "相机";
 "Nagram.Section.Camera.Footer" = "聊天附件面板中的相机入口与实时预览。";
 "Nagram.Section.MessageDisplay" = "消息显示";
+"Nagram.Section.Pangu" = "盘古之白";
 "Nagram.Section.MessageMenu" = "消息菜单";
 "Nagram.Section.Sending" = "发送";
 "Nagram.Section.Gesture" = "手势";
@@ -13,9 +14,13 @@
 "Nagram.Section.Privacy" = "隐私";
 
 "Nagram.SecondsInMessages" = "时间戳显示秒";
+"Nagram.PanguOnReceiving" = "接收消息 Pangu 化";
+"Nagram.PanguInfo" = "使文字更具可读性。在 CJK（中文、日文、韩文）、半宽英文、数字和符号字符之间自动插入空格。";
 "Nagram.HideReactions" = "隐藏消息反应";
 "Nagram.DisableSendAsButton" = "隐藏「以频道身份发送」";
 "Nagram.SendWithReturnKey" = "回车键发送";
+"Nagram.PanguOnSending" = "发送消息 Pangu 化";
+"Nagram.PanguOnEditing" = "编辑消息 Pangu 化";
 "Nagram.HideRecordingButton" = "隐藏语音录制按钮";
 "Nagram.UploadSpeedBoost" = "上传加速";
 "Nagram.Section.Network" = "网络加速";

--- a/Nagram/Strings/Strings/zh-hant.lproj/NagramLocalizable.strings
+++ b/Nagram/Strings/Strings/zh-hant.lproj/NagramLocalizable.strings
@@ -6,6 +6,7 @@
 "Nagram.Section.Camera" = "相機";
 "Nagram.Section.Camera.Footer" = "聊天附件面板中的相機入口與即時預覽。";
 "Nagram.Section.MessageDisplay" = "訊息顯示";
+"Nagram.Section.Pangu" = "盤古之白";
 "Nagram.Section.MessageMenu" = "訊息選單";
 "Nagram.Section.Sending" = "傳送";
 "Nagram.Section.Gesture" = "手勢";
@@ -13,9 +14,13 @@
 "Nagram.Section.Privacy" = "隱私";
 
 "Nagram.SecondsInMessages" = "時間戳顯示秒";
+"Nagram.PanguOnReceiving" = "接收訊息 Pangu 化";
+"Nagram.PanguInfo" = "使文字更具可讀性。在 CJK（中文、日文、韓文）、半形英文、數字和符號字元之間自動插入空格。";
 "Nagram.HideReactions" = "隱藏訊息反應";
 "Nagram.DisableSendAsButton" = "隱藏「以頻道身分傳送」";
 "Nagram.SendWithReturnKey" = "Enter 鍵傳送";
+"Nagram.PanguOnSending" = "傳送訊息 Pangu 化";
+"Nagram.PanguOnEditing" = "編輯訊息 Pangu 化";
 "Nagram.HideRecordingButton" = "隱藏語音錄製按鈕";
 "Nagram.UploadSpeedBoost" = "上傳加速";
 "Nagram.Section.Network" = "網路加速";

--- a/submodules/LegacyMediaPickerUI/BUILD
+++ b/submodules/LegacyMediaPickerUI/BUILD
@@ -29,6 +29,8 @@ swift_library(
         "//submodules/TelegramAnimatedStickerNode:TelegramAnimatedStickerNode",
         "//submodules/StickerResources:StickerResources",
         "//submodules/TextFormat:TextFormat",
+        # MARK: NAGRAM — caption 发送时盘古之白
+        "//Nagram/Settings:NagramSettings",
         "//submodules/DrawingUI:DrawingUI",
         "//submodules/SolidRoundedButtonNode:SolidRoundedButtonNode",
         "//submodules/TelegramUI/Components/MediaEditor",

--- a/submodules/LegacyMediaPickerUI/Sources/LegacyMediaPickers.swift
+++ b/submodules/LegacyMediaPickerUI/Sources/LegacyMediaPickers.swift
@@ -14,6 +14,15 @@ import LocalMediaResources
 import LegacyUI
 import TextFormat
 import Photos
+// MARK: NAGRAM
+import NagramSettings
+
+private func nagramPanguOutgoingText(_ text: NSAttributedString) -> NSAttributedString {
+    guard NagramSettings.shared.enablePanguOnSending else {
+        return text
+    }
+    return NagramPangu.transform(text)
+}
 
 public func guessMimeTypeByFileExtension(_ ext: String) -> String {
     return TGMimeTypeMap.mimeType(forExtension: ext) ?? "application/binary"
@@ -475,7 +484,7 @@ public func legacyAssetPickerEnqueueMessages(
                                                 attributes.append(MediaSpoilerMessageAttribute())
                                             }
                                                                                         
-                                            let text = trimChatInputText(convertMarkdownToAttributes(caption ?? NSAttributedString()))
+                                            let text = nagramPanguOutgoingText(trimChatInputText(convertMarkdownToAttributes(caption ?? NSAttributedString())))
                                             let entities = generateTextEntities(text.string, enabledTypes: .all, currentEntities: generateChatInputTextEntities(text))
                                             if !entities.isEmpty {
                                                 attributes.append(TextEntitiesMessageAttribute(entities: entities))
@@ -566,7 +575,7 @@ public func legacyAssetPickerEnqueueMessages(
                                                         attributes.append(MediaSpoilerMessageAttribute())
                                                     }
                                                     
-                                                    let text = trimChatInputText(convertMarkdownToAttributes(caption ?? NSAttributedString()))
+                                                    let text = nagramPanguOutgoingText(trimChatInputText(convertMarkdownToAttributes(caption ?? NSAttributedString())))
                                                     let entities = generateTextEntities(text.string, enabledTypes: .all, currentEntities: generateChatInputTextEntities(text))
                                                     if !entities.isEmpty {
                                                         attributes.append(TextEntitiesMessageAttribute(entities: entities))
@@ -634,7 +643,7 @@ public func legacyAssetPickerEnqueueMessages(
                                             attributes.append(MediaSpoilerMessageAttribute())
                                         }
                                     
-                                        let text = trimChatInputText(convertMarkdownToAttributes(caption ?? NSAttributedString()))
+                                        let text = nagramPanguOutgoingText(trimChatInputText(convertMarkdownToAttributes(caption ?? NSAttributedString())))
                                         let entities = generateTextEntities(text.string, enabledTypes: .all, currentEntities: generateChatInputTextEntities(text))
                                         if !entities.isEmpty {
                                             attributes.append(TextEntitiesMessageAttribute(entities: entities))
@@ -704,7 +713,7 @@ public func legacyAssetPickerEnqueueMessages(
                                     let media = TelegramMediaFile(fileId: EngineMedia.Id(namespace: Namespaces.Media.LocalFile, id: randomId), partialReference: nil, resource: resource, previewRepresentations: previewRepresentations, videoThumbnails: [], immediateThumbnailData: nil, mimeType: mimeType, size: engineFileSize(path), attributes: [.FileName(fileName: name)], alternativeRepresentations: [])
                                     
                                     var attributes: [EngineMessage.Attribute] = []
-                                    let text = trimChatInputText(convertMarkdownToAttributes(caption ?? NSAttributedString()))
+                                    let text = nagramPanguOutgoingText(trimChatInputText(convertMarkdownToAttributes(caption ?? NSAttributedString())))
                                     let entities = generateTextEntities(text.string, enabledTypes: .all, currentEntities: generateChatInputTextEntities(text))
                                     if !entities.isEmpty {
                                         attributes.append(TextEntitiesMessageAttribute(entities: entities))
@@ -757,7 +766,7 @@ public func legacyAssetPickerEnqueueMessages(
                                     let media = TelegramMediaFile(fileId: EngineMedia.Id(namespace: Namespaces.Media.LocalFile, id: randomId), partialReference: nil, resource: resource, previewRepresentations: [], videoThumbnails: [], immediateThumbnailData: nil, mimeType: mimeType, size: nil, attributes: [.FileName(fileName: name)], alternativeRepresentations: [])
                                     
                                     var attributes: [EngineMessage.Attribute] = []
-                                    let text = trimChatInputText(convertMarkdownToAttributes(caption ?? NSAttributedString()))
+                                    let text = nagramPanguOutgoingText(trimChatInputText(convertMarkdownToAttributes(caption ?? NSAttributedString())))
                                     let entities = generateTextEntities(text.string, enabledTypes: .all, currentEntities: generateChatInputTextEntities(text))
                                     if !entities.isEmpty {
                                         attributes.append(TextEntitiesMessageAttribute(entities: entities))
@@ -977,7 +986,7 @@ public func legacyAssetPickerEnqueueMessages(
                                 attributes.append(MediaSpoilerMessageAttribute())
                             }
                             
-                            let text = trimChatInputText(convertMarkdownToAttributes(caption ?? NSAttributedString()))
+                            let text = nagramPanguOutgoingText(trimChatInputText(convertMarkdownToAttributes(caption ?? NSAttributedString())))
                             let entities = generateTextEntities(text.string, enabledTypes: .all, currentEntities: generateChatInputTextEntities(text))
                             if !entities.isEmpty {
                                 attributes.append(TextEntitiesMessageAttribute(entities: entities))

--- a/submodules/ShareController/BUILD
+++ b/submodules/ShareController/BUILD
@@ -49,6 +49,8 @@ swift_library(
         "//submodules/TelegramUI/Components/Chat/ChatMessagePaymentAlertController",
         "//submodules/ChatPresentationInterfaceState",
         "//submodules/CheckNode",
+        # MARK: NAGRAM — 分享发送时盘古之白
+        "//Nagram/Settings:NagramSettings",
     ],
     visibility = [
         "//visibility:public",

--- a/submodules/ShareController/Sources/ShareController.swift
+++ b/submodules/ShareController/Sources/ShareController.swift
@@ -22,8 +22,24 @@ import MultiAnimationRenderer
 import ObjectiveC
 import UndoUI
 import ChatMessagePaymentAlertController
+// MARK: NAGRAM
+import NagramSettings
 
 private var ObjCKey_DeinitWatcher: Int?
+
+private func nagramPanguShareText(_ text: NSAttributedString) -> NSAttributedString {
+    guard NagramSettings.shared.enablePanguOnSending else {
+        return text
+    }
+    return NagramPangu.transform(text)
+}
+
+private func nagramPanguShareText(_ text: String) -> String {
+    guard NagramSettings.shared.enablePanguOnSending else {
+        return text
+    }
+    return NagramPangu.transform(text).text
+}
 
 private enum ExternalShareItem {
     case text(String)
@@ -1439,11 +1455,12 @@ public final class ShareController: ViewController {
                     }
                     let attributedText = NSMutableAttributedString(string: string, attributes: [ChatTextInputAttributes.italic: true as NSNumber])
                     attributedText.append(NSAttributedString(string: "\n\n\(url)"))
-                    let entities = generateChatInputTextEntities(attributedText)
+                    let panguText = nagramPanguShareText(attributedText)
+                    let entities = generateChatInputTextEntities(panguText)
                     
                     messages.append(StandaloneSendEnqueueMessage(
                         content: .text(text: StandaloneSendEnqueueMessage.Text(
-                            string: attributedText.string,
+                            string: panguText.string,
                             entities: entities
                         )),
                         replyToMessageId: replyToMessageId
@@ -2036,12 +2053,14 @@ public final class ShareController: ViewController {
                     
                     var messages: [EnqueueMessage] = []
                     if !text.isEmpty {
+                        let text = nagramPanguShareText(text)
                         messages.append(.message(text: text, attributes: [], inlineStickers: [:], mediaReference: nil, threadId: threadId, replyToMessageId: replyToMessageId.flatMap { EngineMessageReplySubject(messageId: $0, quote: nil, innerSubject: nil) }, replyToStoryId: nil, localGroupingKey: nil, correlationId: nil, bubbleUpEmojiOrStickersets: []))
                     }
                     let attributedText = NSMutableAttributedString(string: string, attributes: [ChatTextInputAttributes.italic: true as NSNumber])
                     attributedText.append(NSAttributedString(string: "\n\n\(url)"))
-                    let entities = generateChatInputTextEntities(attributedText)
-                    messages.append(.message(text: attributedText.string, attributes: [TextEntitiesMessageAttribute(entities: entities)], inlineStickers: [:], mediaReference: nil, threadId: threadId, replyToMessageId: replyToMessageId.flatMap { EngineMessageReplySubject(messageId: $0, quote: nil, innerSubject: nil) }, replyToStoryId: nil, localGroupingKey: nil, correlationId: nil, bubbleUpEmojiOrStickersets: []))
+                    let panguText = nagramPanguShareText(attributedText)
+                    let entities = generateChatInputTextEntities(panguText)
+                    messages.append(.message(text: panguText.string, attributes: [TextEntitiesMessageAttribute(entities: entities)], inlineStickers: [:], mediaReference: nil, threadId: threadId, replyToMessageId: replyToMessageId.flatMap { EngineMessageReplySubject(messageId: $0, quote: nil, innerSubject: nil) }, replyToStoryId: nil, localGroupingKey: nil, correlationId: nil, bubbleUpEmojiOrStickersets: []))
                     messages = transformMessages(messages, showNames: showNames, silently: silently, sendPaidMessageStars: requiresStars[peerId])
                     shareSignals.append(enqueueMessages(account: currentContext.context.account, peerId: peerId, messages: messages))
                 }

--- a/submodules/TelegramUI/Components/Chat/ChatMessageTextBubbleContentNode/BUILD
+++ b/submodules/TelegramUI/Components/Chat/ChatMessageTextBubbleContentNode/BUILD
@@ -39,6 +39,8 @@ swift_library(
         "//submodules/TelegramUI/Components/InteractiveTextComponent",
         "//submodules/TelegramUI/Components/ShimmeringMask",
         "//submodules/TelegramUI/Components/StreamingTextReveal:StreamingTextReveal",
+        # MARK: NAGRAM — 接收展示时盘古之白
+        "//Nagram/Settings:NagramSettings",
     ],
     visibility = [
         "//visibility:public",

--- a/submodules/TelegramUI/Components/Chat/ChatMessageTextBubbleContentNode/Sources/ChatMessageTextBubbleContentNode.swift
+++ b/submodules/TelegramUI/Components/Chat/ChatMessageTextBubbleContentNode/Sources/ChatMessageTextBubbleContentNode.swift
@@ -27,6 +27,8 @@ import ChatControllerInteraction
 import InteractiveTextComponent
 import ShimmeringMask
 import StreamingTextReveal
+// MARK: NAGRAM
+import NagramSettings
 
 private final class CachedChatMessageText {
     let text: String
@@ -80,6 +82,53 @@ private func findQuoteRange(string: String, quoteText: String, offset: Int?) -> 
         }
     }
     return currentRange
+}
+
+// MARK: NAGRAM — 接收展示时盘古之白需要保护实体内部文本，并同步平移实体 range。
+private func nagramPanguTransformEntities(_ entities: [MessageTextEntity]?, insertedUtf16Offsets: [Int]) -> [MessageTextEntity]? {
+    guard !insertedUtf16Offsets.isEmpty, let entities else {
+        return entities
+    }
+    return entities.map { entity in
+        return MessageTextEntity(range: NagramPangu.transformRange(entity.range, insertedUtf16Offsets: insertedUtf16Offsets), type: entity.type)
+    }
+}
+
+private func nagramPanguProtectedRange(_ entity: MessageTextEntity) -> Range<Int>? {
+    switch entity.type {
+    case .Unknown,
+         .Mention,
+         .Hashtag,
+         .BotCommand,
+         .Url,
+         .Email,
+         .Code,
+         .Pre,
+         .TextUrl,
+         .TextMention,
+         .PhoneNumber,
+         .BankCard,
+         .CustomEmoji,
+         .FormattedDate,
+         .Custom:
+        return entity.range
+    case .Bold,
+         .Italic,
+         .Strikethrough,
+         .BlockQuote,
+         .Underline,
+         .Spoiler:
+        return nil
+    }
+}
+
+private func nagramPanguProtectedRanges(rawText: String, messageEntities: [MessageTextEntity]?) -> [Range<Int>] {
+    var ranges: [Range<Int>] = []
+    if let messageEntities {
+        ranges.append(contentsOf: messageEntities.compactMap(nagramPanguProtectedRange))
+    }
+    ranges.append(contentsOf: generateTextEntities(rawText, enabledTypes: .all).compactMap(nagramPanguProtectedRange))
+    return ranges
 }
 
 public class ChatMessageTextBubbleContentNode: ChatMessageBubbleContentNode {
@@ -453,6 +502,15 @@ public class ChatMessageTextBubbleContentNode: ChatMessageBubbleContentNode {
                         default:
                             return true
                         }
+                    }
+                }
+                
+                // MARK: NAGRAM — 接收 / 历史展示时盘古之白
+                if NagramSettings.shared.enablePanguOnReceiving {
+                    let transform = NagramPangu.transform(rawText, protectedUtf16Ranges: nagramPanguProtectedRanges(rawText: rawText, messageEntities: messageEntities))
+                    if !transform.insertedUtf16Offsets.isEmpty {
+                        rawText = transform.text
+                        messageEntities = nagramPanguTransformEntities(messageEntities, insertedUtf16Offsets: transform.insertedUtf16Offsets)
                     }
                 }
                 

--- a/submodules/TelegramUI/Sources/Chat/ChatControllerLoadDisplayNode.swift
+++ b/submodules/TelegramUI/Sources/Chat/ChatControllerLoadDisplayNode.swift
@@ -78,6 +78,8 @@ import PremiumUI
 import ImageTransparency
 import StickerPackPreviewUI
 import TextNodeWithEntities
+// MARK: NAGRAM
+import NagramSettings
 import EntityKeyboard
 import ChatTitleView
 import EmojiStatusComponent
@@ -2213,7 +2215,11 @@ extension ChatControllerImpl {
                     }
                 }
                 
-                let text = trimChatInputText(convertMarkdownToAttributes(expandedInputStateAttributedString(editMessage.inputState.inputText)))
+                var text = trimChatInputText(convertMarkdownToAttributes(expandedInputStateAttributedString(editMessage.inputState.inputText)))
+                // MARK: NAGRAM — 编辑时盘古之白
+                if NagramSettings.shared.enablePanguOnEditing {
+                    text = NagramPangu.transform(text)
+                }
 
                 var isSpecialChatContents = false
                 if case .customChatContents = strongSelf.presentationInterfaceState.subject {

--- a/submodules/TelegramUI/Sources/ChatControllerForwardMessages.swift
+++ b/submodules/TelegramUI/Sources/ChatControllerForwardMessages.swift
@@ -13,6 +13,8 @@ import PremiumUI
 import ReactionSelectionNode
 import TopMessageReactions
 import ChatMessagePaymentAlertController
+// MARK: NAGRAM
+import NagramSettings
 
 extension ChatControllerImpl {
     func forwardMessages(messageIds: [EngineMessage.Id], options: ChatInterfaceForwardOptionsState? = nil, resetCurrent: Bool = false) {
@@ -139,7 +141,11 @@ extension ChatControllerImpl {
                         
                         var result: [EnqueueMessage] = []
                         if messageText.string.count > 0 {
-                            let inputText = convertMarkdownToAttributes(messageText)
+                            var inputText = convertMarkdownToAttributes(messageText)
+                            // MARK: NAGRAM — 转发附言发送时盘古之白
+                            if NagramSettings.shared.enablePanguOnSending {
+                                inputText = NagramPangu.transform(inputText)
+                            }
                             for text in breakChatInputText(trimChatInputText(inputText)) {
                                 if text.length != 0 {
                                     var attributes: [EngineMessage.Attribute] = []

--- a/submodules/TelegramUI/Sources/ChatControllerNode.swift
+++ b/submodules/TelegramUI/Sources/ChatControllerNode.swift
@@ -4855,7 +4855,11 @@ class ChatControllerNode: ASDisplayNode, ASScrollViewDelegate {
             if peerId?.namespace != Namespaces.Peer.SecretChat, let interactiveEmojis = self.interactiveEmojis, interactiveEmojis.emojis.contains(trimmedInputText), effectiveInputText.attribute(ChatTextInputAttributes.customEmoji, at: 0, effectiveRange: nil) == nil {
                 messages.append(.message(text: "", attributes: [], inlineStickers: [:], mediaReference: AnyMediaReference.standalone(media: TelegramMediaDice(emoji: trimmedInputText)), threadId: self.chatLocation.threadId, replyToMessageId: self.chatPresentationInterfaceState.interfaceState.replyMessageSubject?.subjectModel, replyToStoryId: nil, localGroupingKey: nil, correlationId: nil, bubbleUpEmojiOrStickersets: []))
             } else {
-                let inputText = convertMarkdownToAttributes(effectiveInputText)
+                var inputText = convertMarkdownToAttributes(effectiveInputText)
+                // MARK: NAGRAM — 发送时盘古之白
+                if NagramSettings.shared.enablePanguOnSending {
+                    inputText = NagramPangu.transform(inputText)
+                }
                 
                 var mediaReference: AnyMediaReference?
                 var webpage: TelegramMediaWebpage?

--- a/submodules/TelegramUI/Sources/ChatControllerOpenAttachmentMenu.swift
+++ b/submodules/TelegramUI/Sources/ChatControllerOpenAttachmentMenu.swift
@@ -35,6 +35,8 @@ import ComposeTodoScreen
 import ComposePollScreen
 import Photos
 import AttachmentFileController
+// MARK: NAGRAM
+import NagramSettings
 
 extension ChatControllerImpl {
     enum AttachMenuSubject {
@@ -387,6 +389,7 @@ extension ChatControllerImpl {
                         var attributes: [EngineMessage.Attribute] = []
                         var text = ""
                         if let caption {
+                            let caption = NagramSettings.shared.enablePanguOnSending ? NagramPangu.transform(caption) : caption
                             text = caption.string
                             let entities = generateTextEntities(text, enabledTypes: .all, currentEntities: generateChatInputTextEntities(caption))
                             if !entities.isEmpty {
@@ -437,6 +440,7 @@ extension ChatControllerImpl {
                         var attributes: [EngineMessage.Attribute] = []
                         var text = ""
                         if let caption {
+                            let caption = NagramSettings.shared.enablePanguOnSending ? NagramPangu.transform(caption) : caption
                             text = caption.string
                             let entities = generateTextEntities(text, enabledTypes: .all, currentEntities: generateChatInputTextEntities(caption))
                             if !entities.isEmpty {
@@ -538,6 +542,7 @@ extension ChatControllerImpl {
                         if let strongSelf = self, let (peers, _, silent, scheduleTime, text, parameters) = peers {
                             var textEnqueueMessage: EnqueueMessage?
                             if let text = text, text.length > 0 {
+                                let text = NagramSettings.shared.enablePanguOnSending ? NagramPangu.transform(text) : text
                                 var attributes: [EngineMessage.Attribute] = []
                                 let entities = generateTextEntities(text.string, enabledTypes: .all, currentEntities: generateChatInputTextEntities(text))
                                 if !entities.isEmpty {


### PR DESCRIPTION
## Summary
- Fixes #15.
- Add Nagram Pangu spacing settings for send, edit, and incoming display.
- Group the three Pangu toggles under a dedicated Pangu settings section with Nagram-style labels and explanatory footer.
- Apply send/edit transforms after markdown conversion and shift displayed incoming message entity ranges after local spacing.
- Ignore jj workspaces and Bazel workspace symlinks.

## Verification
- Pangu transform Swift assertion harness passed with exit code 0.
- Full build passed: /run/current-system/sw/bin/zsh -lc 'source ~/.zshrc 2>/dev/null; python3 build-system/Make/Make.py --overrideXcodeVersion --cacheDir ~/telegram-bazel-cache build --configurationPath build-input/local-configuration.json --codesigningInformationPath build-input/codesigning-development --buildNumber=1 --configuration=debug_arm64 --continueOnError'