### PR TITLE
feat: add quick return recent chats

### DIFF
--- a/Nagram/Settings/NagramRecentChats.swift
+++ b/Nagram/Settings/NagramRecentChats.swift
@@ -1,0 +1,109 @@
+import Foundation
+
+public extension Notification.Name {
+    static let nagramRecentChatsDidChange = Notification.Name("NagramRecentChatsDidChange")
+    static let nagramRecentChatFolderSettingsDidChange = Notification.Name("NagramRecentChatFolderSettingsDidChange")
+}
+
+// MARK: NAGRAM — 最近会话存储。字符串落盘,由 UI 侧负责 PeerId 往返。
+public extension NagramSettings {
+    private var recentChatsLimit: Int {
+        return 50
+    }
+
+    private func recentChatsKey(accountPeerId: Int64) -> String {
+        return "nagram.recentChats.\(accountPeerId)"
+    }
+    
+    private func recentChatFoldersKey(accountPeerId: Int64) -> String {
+        return "nagram.recentChatFolders.\(accountPeerId)"
+    }
+
+    func recentChatIds(accountPeerId: Int64, limit: Int? = nil) -> [Int64] {
+        let values = UserDefaults.standard.stringArray(forKey: self.recentChatsKey(accountPeerId: accountPeerId))?.compactMap(Int64.init) ?? []
+        if let limit {
+            return Array(values.prefix(limit))
+        } else {
+            return values
+        }
+    }
+    
+    func isRecentChatFolderEnabled(accountPeerId: Int64, filterId: Int32) -> Bool {
+        guard filterId > 0 else {
+            return false
+        }
+        return UserDefaults.standard.stringArray(forKey: self.recentChatFoldersKey(accountPeerId: accountPeerId))?.contains(String(filterId)) ?? false
+    }
+    
+    func hasRecentChatFolderEnabled(accountPeerId: Int64) -> Bool {
+        return !(UserDefaults.standard.stringArray(forKey: self.recentChatFoldersKey(accountPeerId: accountPeerId)) ?? []).isEmpty
+    }
+    
+    func setRecentChatFolderEnabled(_ enabled: Bool, accountPeerId: Int64, filterId: Int32) {
+        guard filterId > 0 else {
+            return
+        }
+        
+        let key = self.recentChatFoldersKey(accountPeerId: accountPeerId)
+        var values = Set(UserDefaults.standard.stringArray(forKey: key) ?? [])
+        let id = String(filterId)
+        let hadValue = values.contains(id)
+        if enabled {
+            values.insert(id)
+        } else {
+            values.remove(id)
+        }
+        if values.isEmpty {
+            UserDefaults.standard.removeObject(forKey: key)
+        } else {
+            UserDefaults.standard.set(Array(values).sorted(), forKey: key)
+        }
+        
+        if hadValue != enabled {
+            NotificationCenter.default.post(
+                name: .nagramRecentChatFolderSettingsDidChange,
+                object: self,
+                userInfo: ["accountPeerId": accountPeerId, "filterId": filterId]
+            )
+        }
+    }
+
+    func addRecentChatId(_ peerId: Int64, accountPeerId: Int64) {
+        guard self.recentChatsEnabled || self.hasRecentChatFolderEnabled(accountPeerId: accountPeerId) else {
+            return
+        }
+        var values = self.recentChatIds(accountPeerId: accountPeerId)
+        values.removeAll(where: { $0 == peerId })
+        values.insert(peerId, at: 0)
+        if values.count > self.recentChatsLimit {
+            values.removeSubrange(self.recentChatsLimit ..< values.count)
+        }
+        UserDefaults.standard.set(values.map { String($0) }, forKey: self.recentChatsKey(accountPeerId: accountPeerId))
+        NotificationCenter.default.post(
+            name: .nagramRecentChatsDidChange,
+            object: self,
+            userInfo: ["accountPeerId": accountPeerId]
+        )
+    }
+    
+    func removeRecentChatId(_ peerId: Int64, accountPeerId: Int64) {
+        var values = self.recentChatIds(accountPeerId: accountPeerId)
+        let previousCount = values.count
+        values.removeAll(where: { $0 == peerId })
+        guard values.count != previousCount else {
+            return
+        }
+        
+        let key = self.recentChatsKey(accountPeerId: accountPeerId)
+        if values.isEmpty {
+            UserDefaults.standard.removeObject(forKey: key)
+        } else {
+            UserDefaults.standard.set(values.map { String($0) }, forKey: key)
+        }
+        NotificationCenter.default.post(
+            name: .nagramRecentChatsDidChange,
+            object: self,
+            userInfo: ["accountPeerId": accountPeerId]
+        )
+    }
+}

--- a/Nagram/Settings/NagramRecentChats.swift
+++ b/Nagram/Settings/NagramRecentChats.swift
@@ -73,6 +73,9 @@ public extension NagramSettings {
             return
         }
         var values = self.recentChatIds(accountPeerId: accountPeerId)
+        if values.first == peerId {
+            return
+        }
         values.removeAll(where: { $0 == peerId })
         values.insert(peerId, at: 0)
         if values.count > self.recentChatsLimit {

--- a/Nagram/Settings/NagramSettings.swift
+++ b/Nagram/Settings/NagramSettings.swift
@@ -139,6 +139,9 @@ public final class NagramSettings {
     /// 对话列表横滑行为（"both" / "switch" / "quick" / "none"）
     @NagramDefault("nagram.chatListSwipeAction", NagramChatListSwipeAction.both.rawValue)
     public var chatListSwipeAction: String
+    /// 最近会话快捷入口
+    @NagramDefault("nagram.recentChatsEnabled", false)
+    public var recentChatsEnabled: Bool
     /// 资料页显示用户数字 ID（默认关 = 保持原生）
     @NagramDefault("nagram.showProfileId", false)
     public var showProfileId: Bool

--- a/Nagram/SettingsUI/NagramSettingsController.swift
+++ b/Nagram/SettingsUI/NagramSettingsController.swift
@@ -112,6 +112,7 @@ private func nagramGroups(
             .toggle(titleKey: "Nagram.HideRecordingButton", get: { NagramSettings.shared.hideRecordingButton }, set: { NagramSettings.shared.hideRecordingButton = $0 }),
         ]),
         NagramGroup(tab: .chat, headerKey: "Nagram.Section.Gesture", footerKey: "Nagram.Section.Gesture.Footer", rows: [
+            .toggle(titleKey: "Nagram.RecentChats", get: { NagramSettings.shared.recentChatsEnabled }, set: { NagramSettings.shared.recentChatsEnabled = $0 }),
             .choice(titleKey: "Nagram.ChatListSwipeAction", prefix: "Nagram.ChatListSwipeAction", options: ["both", "switch", "quick", "none"], current: { NagramSettings.shared.chatListSwipeActionMode.rawValue }, set: { NagramSettings.shared.chatListSwipeAction = $0 }),
             .toggle(titleKey: "Nagram.DisableScrollToNextChannel", get: { NagramSettings.shared.disableScrollToNextChannel }, set: { NagramSettings.shared.disableScrollToNextChannel = $0 }),
             .toggle(titleKey: "Nagram.DisableScrollToNextTopic", get: { NagramSettings.shared.disableScrollToNextTopic }, set: { NagramSettings.shared.disableScrollToNextTopic = $0 }),

--- a/Nagram/Strings/Strings/en.lproj/NagramLocalizable.strings
+++ b/Nagram/Strings/Strings/en.lproj/NagramLocalizable.strings
@@ -121,3 +121,5 @@
 "Nagram.HideTabBarSettings" = "Hide Settings";
 "Nagram.ShowTabBarSearch" = "Hide Top Search";
 "Nagram.WideTabBar" = "Show Wide Tab Bar";
+"Nagram.RecentChats" = "Quick Return to Recent Chats";
+"Nagram.ChatListFolder.CategoryRecent" = "Recent";

--- a/Nagram/Strings/Strings/ja.lproj/NagramLocalizable.strings
+++ b/Nagram/Strings/Strings/ja.lproj/NagramLocalizable.strings
@@ -121,3 +121,5 @@
 "Nagram.HideTabBarSettings" = "設定を非表示";
 "Nagram.ShowTabBarSearch" = "上部検索を非表示";
 "Nagram.WideTabBar" = "幅広のタブバーを表示";
+"Nagram.RecentChats" = "最近のチャットへ素早く戻る";
+"Nagram.ChatListFolder.CategoryRecent" = "最近";

--- a/Nagram/Strings/Strings/zh-hans.lproj/NagramLocalizable.strings
+++ b/Nagram/Strings/Strings/zh-hans.lproj/NagramLocalizable.strings
@@ -121,3 +121,5 @@
 "Nagram.HideTabBarSettings" = "隐藏设置";
 "Nagram.ShowTabBarSearch" = "隐藏顶部搜索";
 "Nagram.WideTabBar" = "展示宽底栏";
+"Nagram.RecentChats" = "快速返回最近会话";
+"Nagram.ChatListFolder.CategoryRecent" = "最近";

--- a/Nagram/Strings/Strings/zh-hant.lproj/NagramLocalizable.strings
+++ b/Nagram/Strings/Strings/zh-hant.lproj/NagramLocalizable.strings
@@ -121,3 +121,5 @@
 "Nagram.HideTabBarSettings" = "隱藏設定";
 "Nagram.ShowTabBarSearch" = "隱藏頂部搜尋";
 "Nagram.WideTabBar" = "顯示寬底欄";
+"Nagram.RecentChats" = "快速返回最近會話";
+"Nagram.ChatListFolder.CategoryRecent" = "最近";

--- a/submodules/ChatListUI/BUILD
+++ b/submodules/ChatListUI/BUILD
@@ -134,6 +134,7 @@ swift_library(
         # MARK: NAGRAM
         "//Nagram/SettingsSignal:NagramSettingsSignal",
         "//Nagram/Settings:NagramSettings",
+        "//Nagram/Strings:NagramStrings",
     ],
     visibility = [
         "//visibility:public",

--- a/submodules/ChatListUI/Sources/ChatContextMenus.swift
+++ b/submodules/ChatListUI/Sources/ChatContextMenus.swift
@@ -207,13 +207,17 @@ func chatContextMenuItems(context: AccountContext, peerId: EnginePeer.Id, promoI
                                     let nagramPeerId = peer.id.toInt64()
                                     if NagramSettings.shared.isRecentChatFolderEnabled(accountPeerId: nagramAccountPeerId, filterId: id),
                                        NagramSettings.shared.recentChatIds(accountPeerId: nagramAccountPeerId).contains(nagramPeerId) {
-                                        NagramSettings.shared.removeRecentChatId(nagramPeerId, accountPeerId: nagramAccountPeerId)
-                                        c?.dismiss(completion: {
-                                            chatListController?.present(UndoOverlayController(presentationData: presentationData, content: .chatRemovedFromFolder(context: context, chatTitle: peer.displayTitle(strings: presentationData.strings, displayOrder: presentationData.nameDisplayOrder), folderTitle: title.rawAttributedString), elevatedLayout: false, animateInAsReplacement: true, action: { _ in
-                                                return false
-                                            }), in: .current)
-                                        })
-                                        return
+                                        let predicateWithoutRecent = chatListFilterPredicate(filter: data, accountPeerId: context.account.peerId, includeRecentPeerIds: Set())
+                                        let includedWithoutRecent = predicateWithoutRecent.includes(peer: peer._asPeer(), groupId: .root, isRemovedFromTotalUnreadCount: isMuted, isUnread: isUnread, isContact: isContact, messageTagSummaryResult: false)
+                                        if !includedWithoutRecent {
+                                            NagramSettings.shared.removeRecentChatId(nagramPeerId, accountPeerId: nagramAccountPeerId)
+                                            c?.dismiss(completion: {
+                                                chatListController?.present(UndoOverlayController(presentationData: presentationData, content: .chatRemovedFromFolder(context: context, chatTitle: peer.displayTitle(strings: presentationData.strings, displayOrder: presentationData.nameDisplayOrder), folderTitle: title.rawAttributedString), elevatedLayout: false, animateInAsReplacement: true, action: { _ in
+                                                    return false
+                                                }), in: .current)
+                                            })
+                                            return
+                                        }
                                     }
                                     let _ = (context.engine.peers.updateChatListFiltersInteractively { filters in
                                         var filters = filters

--- a/submodules/ChatListUI/Sources/ChatContextMenus.swift
+++ b/submodules/ChatListUI/Sources/ChatContextMenus.swift
@@ -15,6 +15,7 @@ import TelegramPresentationData
 import TelegramStringFormatting
 import ChatTimerScreen
 import NotificationPeerExceptionController
+import NagramSettings // MARK: NAGRAM
 
 func archiveContextMenuItems(context: AccountContext, group: EngineChatList.Group, chatListController: ChatListControllerImpl?) -> Signal<[ContextMenuItem], NoError> {
     let presentationData = context.sharedContext.currentPresentationData.with({ $0 })
@@ -202,6 +203,18 @@ func chatContextMenuItems(context: AccountContext, peerId: EnginePeer.Id, promoI
                         if case let .chatList(currentFilter) = source {
                             if let currentFilter = currentFilter, case let .filter(id, title, emoticon, data) = currentFilter {
                                 items.append(.action(ContextMenuActionItem(text: strings.ChatList_Context_RemoveFromFolder, icon: { theme in generateTintedImage(image: UIImage(bundleImageName: "Chat/Context Menu/RemoveFromFolder"), color: theme.contextMenu.primaryColor) }, action: { c, _ in
+                                    let nagramAccountPeerId = context.account.peerId.toInt64() // MARK: NAGRAM
+                                    let nagramPeerId = peer.id.toInt64()
+                                    if NagramSettings.shared.isRecentChatFolderEnabled(accountPeerId: nagramAccountPeerId, filterId: id),
+                                       NagramSettings.shared.recentChatIds(accountPeerId: nagramAccountPeerId).contains(nagramPeerId) {
+                                        NagramSettings.shared.removeRecentChatId(nagramPeerId, accountPeerId: nagramAccountPeerId)
+                                        c?.dismiss(completion: {
+                                            chatListController?.present(UndoOverlayController(presentationData: presentationData, content: .chatRemovedFromFolder(context: context, chatTitle: peer.displayTitle(strings: presentationData.strings, displayOrder: presentationData.nameDisplayOrder), folderTitle: title.rawAttributedString), elevatedLayout: false, animateInAsReplacement: true, action: { _ in
+                                                return false
+                                            }), in: .current)
+                                        })
+                                        return
+                                    }
                                     let _ = (context.engine.peers.updateChatListFiltersInteractively { filters in
                                         var filters = filters
                                         for i in 0 ..< filters.count {
@@ -229,8 +242,8 @@ func chatContextMenuItems(context: AccountContext, peerId: EnginePeer.Id, promoI
                         if !hasRemoveFromFolder && peerGroup != nil {
                             var hasFolders = false
                             
-                            for case let .filter(_, _, _, data) in filters {
-                                let predicate = chatListFilterPredicate(filter: data, accountPeerId: context.account.peerId)
+                            for case let .filter(filterId, _, _, data) in filters {
+                                let predicate = chatListFilterPredicate(filter: data, accountPeerId: context.account.peerId, includeRecentPeerIds: nagramChatListFilterRecentPeerIds(accountPeerId: context.account.peerId, filterId: filterId))
                                 if predicate.includes(peer: peer._asPeer(), groupId: .root, isRemovedFromTotalUnreadCount: isMuted, isUnread: isUnread, isContact: isContact, messageTagSummaryResult: false) {
                                     continue
                                 }
@@ -254,8 +267,8 @@ func chatContextMenuItems(context: AccountContext, peerId: EnginePeer.Id, promoI
                                     updatedItems.append(.separator)
                                     
                                     for filter in filters {
-                                        if case let .filter(_, title, _, data) = filter {
-                                            let predicate = chatListFilterPredicate(filter: data, accountPeerId: context.account.peerId)
+                                        if case let .filter(filterId, title, _, data) = filter {
+                                            let predicate = chatListFilterPredicate(filter: data, accountPeerId: context.account.peerId, includeRecentPeerIds: nagramChatListFilterRecentPeerIds(accountPeerId: context.account.peerId, filterId: filterId))
                                             if predicate.includes(peer: peer._asPeer(), groupId: .root, isRemovedFromTotalUnreadCount: isMuted, isUnread: isUnread, isContact: isContact, messageTagSummaryResult: false) {
                                                 continue
                                             }

--- a/submodules/ChatListUI/Sources/ChatListController.swift
+++ b/submodules/ChatListUI/Sources/ChatListController.swift
@@ -974,11 +974,11 @@ public class ChatListControllerImpl: TelegramBaseController, ChatListController 
             guard let filter = filters.first(where: { $0.id == id }) else {
                 return .single(nil)
             }
-            guard case let .filter(_, _, _, data) = filter else {
+            guard case let .filter(filterId, _, _, data) = filter else {
                 return .single(nil)
             }
             
-            let filterPredicate: ChatListFilterPredicate = chatListFilterPredicate(filter: data, accountPeerId: context.account.peerId)
+            let filterPredicate: ChatListFilterPredicate = chatListFilterPredicate(filter: data, accountPeerId: context.account.peerId, includeRecentPeerIds: nagramChatListFilterRecentPeerIds(accountPeerId: context.account.peerId, filterId: filterId))
             return context.engine.peers.getChatListPeers(filterPredicate: filterPredicate)
             |> mapToSignal { peers -> Signal<(areMuted: Bool, peerIds: [EnginePeer.Id])?, NoError> in
                 let peerIds = peers.map(\.id)
@@ -4139,7 +4139,7 @@ public class ChatListControllerImpl: TelegramBaseController, ChatListController 
     private func readAllInFilter(id: Int32) {
         for filter in self.chatListDisplayNode.mainContainerNode.availableFilters {
             if case let .filter(filter) = filter, case let .filter(filterId, _, _, data) = filter, filterId == id {
-                let filterPredicate = chatListFilterPredicate(filter: data, accountPeerId: self.context.account.peerId)
+                let filterPredicate = chatListFilterPredicate(filter: data, accountPeerId: self.context.account.peerId, includeRecentPeerIds: nagramChatListFilterRecentPeerIds(accountPeerId: self.context.account.peerId, filterId: filterId))
                 var markItems: [(groupId: EngineChatList.Group, filterPredicate: ChatListFilterPredicate?)] = []
                 markItems.append((.root, filterPredicate))
                 for additionalGroupId in filterPredicate.includeAdditionalPeerGroupIds {
@@ -4502,6 +4502,7 @@ public class ChatListControllerImpl: TelegramBaseController, ChatListController 
                 let _ = (strongSelf.context.engine.peers.updateChatListFiltersInteractively { filters in
                     return filters.filter({ $0.id != id })
                 }).startStandalone()
+                NagramSettings.shared.setRecentChatFolderEnabled(false, accountPeerId: strongSelf.context.account.peerId.toInt64(), filterId: id) // MARK: NAGRAM — 清理本地最近文件夹状态
             }
             
             if strongSelf.chatListDisplayNode.mainContainerNode.currentItemNode.chatListFilter?.id == id {
@@ -4582,6 +4583,7 @@ public class ChatListControllerImpl: TelegramBaseController, ChatListController 
                                     guard let self else {
                                         return
                                     }
+                                    NagramSettings.shared.setRecentChatFolderEnabled(false, accountPeerId: self.context.account.peerId.toInt64(), filterId: id) // MARK: NAGRAM — 清理本地最近文件夹状态
                                     if self.chatListDisplayNode.mainContainerNode.currentItemNode.chatListFilter?.id == id {
                                         self.chatListDisplayNode.mainContainerNode.switchToFilter(id: .all, completion: {
                                         })
@@ -4901,8 +4903,8 @@ public class ChatListControllerImpl: TelegramBaseController, ChatListController 
                 signal = self.context.engine.messages.togglePeersUnreadMarkInteractively(peerIds: Array(peerIds), setToValue: false)
             } else if case let .chatList(groupId) = self.chatListDisplayNode.effectiveContainerNode.location {
                 let filterPredicate: ChatListFilterPredicate?
-                if let filter = self.chatListDisplayNode.effectiveContainerNode.currentItemNode.chatListFilter, case let .filter(_, _, _, data) = filter {
-                    filterPredicate = chatListFilterPredicate(filter: data, accountPeerId: self.context.account.peerId)
+                if let filter = self.chatListDisplayNode.effectiveContainerNode.currentItemNode.chatListFilter, case let .filter(filterId, _, _, data) = filter {
+                    filterPredicate = chatListFilterPredicate(filter: data, accountPeerId: self.context.account.peerId, includeRecentPeerIds: nagramChatListFilterRecentPeerIds(accountPeerId: self.context.account.peerId, filterId: filterId))
                 } else {
                     filterPredicate = nil
                 }
@@ -6242,6 +6244,82 @@ public class ChatListControllerImpl: TelegramBaseController, ChatListController 
     }
     
     override public func tabBarItemContextAction(sourceView: ContextExtractedContentContainingView, gesture: ContextGesture) {
+        // MARK: NAGRAM — 长按 Chats tab 显示最近会话
+        if NagramSettings.shared.recentChatsEnabled && !NagramSettings.shared.recentChatIds(accountPeerId: self.context.account.peerId.toInt64(), limit: 1).isEmpty {
+            self.displayNagramRecentChatsMenu(sourceView: sourceView, gesture: gesture, fallback: { [weak self, weak sourceView] in
+                guard let self, let sourceView else {
+                    return
+                }
+                self.displayChatListTabBarContextMenu(sourceView: sourceView, gesture: gesture)
+            })
+            return
+        }
+        
+        self.displayChatListTabBarContextMenu(sourceView: sourceView, gesture: gesture)
+    }
+    
+    private func displayNagramRecentChatsMenu(sourceView: ContextExtractedContentContainingView, gesture: ContextGesture, fallback: @escaping () -> Void) {
+        let peerIds = NagramSettings.shared.recentChatIds(accountPeerId: self.context.account.peerId.toInt64(), limit: 25).map { EnginePeer.Id($0) }
+        guard !peerIds.isEmpty else {
+            fallback()
+            return
+        }
+        
+        let peerMap = EngineDataMap(
+            Set(peerIds).map(TelegramEngine.EngineData.Item.Peer.Peer.init)
+        )
+        let _ = (self.context.engine.data.get(
+            peerMap
+        )
+        |> deliverOnMainQueue).startStandalone(next: { [weak self, weak sourceView] peerMap in
+            guard let self, let sourceView else {
+                return
+            }
+            
+            var items: [ContextMenuItem] = []
+            
+            for peerId in peerIds {
+                guard let maybePeer = peerMap[peerId], let peer = maybePeer else {
+                    continue
+                }
+                
+                let isSavedMessages = peer.id == self.context.account.peerId
+                let title: String
+                if isSavedMessages {
+                    title = self.presentationData.strings.DialogList_SavedMessages
+                } else {
+                    title = peer.displayTitle(strings: self.presentationData.strings, displayOrder: self.presentationData.nameDisplayOrder)
+                }
+                
+                items.append(.action(ContextMenuActionItem(text: title, icon: { _ in
+                    return nil
+                }, action: { [weak self] _, f in
+                    f(.default)
+                    
+                    guard let self, let navigationController = self.navigationController as? NavigationController else {
+                        return
+                    }
+                    
+                    self.context.sharedContext.navigateToChatController(NavigateToChatControllerParams(
+                        navigationController: navigationController,
+                        context: self.context,
+                        chatLocation: .peer(peer),
+                        animated: true
+                    ))
+                })))
+            }
+            
+            if items.isEmpty {
+                fallback()
+                return
+            }
+            
+            let controller = makeContextController(context: self.context, presentationData: self.presentationData, source: .reference(ChatListTabBarContextReferenceContentSource(controller: self, sourceView: sourceView)), items: .single(ContextController.Items(content: .list(items))), recognizer: nil, gesture: gesture)
+            self.context.sharedContext.mainWindow?.presentInGlobalOverlay(controller)
+        })
+    }
+    
+    private func displayChatListTabBarContextMenu(sourceView: ContextExtractedContentContainingView, gesture: ContextGesture) {
         let _ = (combineLatest(queue: .mainQueue(),
             self.context.engine.peers.currentChatListFilters(),
             chatListFilterItems(context: self.context)

--- a/submodules/ChatListUI/Sources/ChatListFilterPresetCategoryItem.swift
+++ b/submodules/ChatListUI/Sources/ChatListFilterPresetCategoryItem.swift
@@ -16,6 +16,7 @@ enum ChatListFilterCategoryIcon {
     case groups
     case channels
     case bots
+    case recent
     case muted
     case read
     case archived
@@ -260,6 +261,9 @@ class ChatListFilterPresetCategoryItemNode: ItemListRevealOptionsItemNode, ItemL
                         case .bots:
                             color = .violet
                             imageName = "Chat List/Filters/Bot"
+                        case .recent:
+                            color = .blue
+                            imageName = "Chat List/Filters/Read"
                         case .muted:
                             color = .red
                             imageName = "Chat List/Filters/Muted"

--- a/submodules/ChatListUI/Sources/ChatListFilterPresetController.swift
+++ b/submodules/ChatListUI/Sources/ChatListFilterPresetController.swift
@@ -25,6 +25,8 @@ import ChatEntityKeyboardInputNode
 import ComponentFlow
 import ChatPresentationInterfaceState
 import ComponentDisplayAdapters
+import NagramSettings // MARK: NAGRAM
+import NagramStrings // MARK: NAGRAM
 
 private enum FilterSection: Int32, Hashable {
     case include
@@ -146,8 +148,9 @@ private enum ChatListFilterIncludeCategory: Int32, CaseIterable {
     case groups
     case channels
     case bots
+    case recent
     
-    var category: ChatListFilterPeerCategories {
+    var category: ChatListFilterPeerCategories? {
         switch self {
         case .contacts:
             return .contacts
@@ -159,6 +162,8 @@ private enum ChatListFilterIncludeCategory: Int32, CaseIterable {
             return .channels
         case .bots:
             return .bots
+        case .recent:
+            return nil
         }
     }
     
@@ -174,6 +179,8 @@ private enum ChatListFilterIncludeCategory: Int32, CaseIterable {
             return strings.ChatListFolder_CategoryChannels
         case .bots:
             return strings.ChatListFolder_CategoryBots
+        case .recent:
+            return ngI18n("Nagram.ChatListFolder.CategoryRecent", strings.baseLanguageCode)
         }
     }
 }
@@ -208,6 +215,8 @@ private extension ChatListFilterCategoryIcon {
             self = .channels
         case .bots:
             self = .bots
+        case .recent:
+            self = .recent
         }
     }
     
@@ -555,6 +564,7 @@ private struct ChatListFilterPresetControllerState: Equatable {
     var color: PeerNameColor?
     var colorUpdated: Bool = false
     var includeCategories: ChatListFilterPeerCategories
+    var includeRecent: Bool
     var excludeMuted: Bool
     var excludeRead: Bool
     var excludeArchived: Bool
@@ -579,13 +589,14 @@ private struct ChatListFilterPresetControllerState: Equatable {
         let defaultExcludeRead = false
         
         if self.includeCategories == defaultCategories &&
+           !self.includeRecent &&
            self.excludeArchived == defaultExcludeArchived &&
            self.excludeMuted == defaultExcludeMuted &&
            self.excludeRead == defaultExcludeRead {
            return false
         }
         
-        if self.includeCategories.isEmpty && self.additionallyIncludePeers.isEmpty {
+        if self.includeCategories.isEmpty && self.additionallyIncludePeers.isEmpty && !self.includeRecent {
             return false
         }
         
@@ -610,7 +621,15 @@ private func chatListFilterPresetControllerEntries(context: AccountContext, pres
     
     var includeCategoryIndex = 0
     for category in ChatListFilterIncludeCategory.allCases {
-        if state.includeCategories.contains(category.category) {
+        let isSelected: Bool
+        if case .recent = category {
+            isSelected = state.includeRecent
+        } else if let categoryValue = category.category {
+            isSelected = state.includeCategories.contains(categoryValue)
+        } else {
+            isSelected = false
+        }
+        if isSelected {
             entries.append(.includeCategory(index: includeCategoryIndex, category: category, title: category.title(strings: presentationData.strings), isRevealed: state.revealedItemId == .includeCategory(category)))
         }
         includeCategoryIndex += 1
@@ -717,6 +736,7 @@ private enum AdditionalCategoryId: Int {
     case groups
     case channels
     case bots
+    case recent
 }
 
 private enum AdditionalExcludeCategoryId: Int {
@@ -726,10 +746,11 @@ private enum AdditionalExcludeCategoryId: Int {
 }
 
 func chatListFilterAddChatsController(context: AccountContext, filter: ChatListFilter, allFilters: [ChatListFilter], limit: Int32, premiumLimit: Int32, isPremium: Bool, presentUndo: @escaping (UndoOverlayContent) -> Void) -> ViewController {
-    return internalChatListFilterAddChatsController(context: context, filter: filter, allFilters: allFilters, applyAutomatically: true, limit: limit, premiumLimit: premiumLimit, isPremium: isPremium, updated: { _ in }, presentUndo: presentUndo)
+    let includeRecent = NagramSettings.shared.isRecentChatFolderEnabled(accountPeerId: context.account.peerId.toInt64(), filterId: filter.id)
+    return internalChatListFilterAddChatsController(context: context, filter: filter, includeRecent: includeRecent, allFilters: allFilters, applyAutomatically: true, limit: limit, premiumLimit: premiumLimit, isPremium: isPremium, updated: { _, _ in }, presentUndo: presentUndo)
 }
     
-private func internalChatListFilterAddChatsController(context: AccountContext, filter: ChatListFilter, allFilters: [ChatListFilter], applyAutomatically: Bool, limit: Int32, premiumLimit: Int32, isPremium: Bool, updated: @escaping (ChatListFilter) -> Void, presentUndo: @escaping (UndoOverlayContent) -> Void) -> ViewController {
+private func internalChatListFilterAddChatsController(context: AccountContext, filter: ChatListFilter, includeRecent: Bool, allFilters: [ChatListFilter], applyAutomatically: Bool, limit: Int32, premiumLimit: Int32, isPremium: Bool, updated: @escaping (ChatListFilter, Bool) -> Void, presentUndo: @escaping (UndoOverlayContent) -> Void) -> ViewController {
     guard case let .filter(_, _, _, filterData) = filter else {
         return ViewController(navigationBarPresentationData: nil)
     }
@@ -777,6 +798,12 @@ private func internalChatListFilterAddChatsController(context: AccountContext, f
                 icon: generateAvatarImage(size: CGSize(width: 40.0, height: 40.0), icon: generateTintedImage(image: UIImage(bundleImageName: "Chat List/Filters/Bot"), color: .white), cornerRadius: 12.0, color: .violet),
                 smallIcon: generateAvatarImage(size: CGSize(width: 22.0, height: 22.0), icon: generateTintedImage(image: UIImage(bundleImageName: "Chat List/Filters/Bot"), color: .white), iconScale: 0.6, cornerRadius: 6.0, circleCorners: true, color: .violet),
                 title: presentationData.strings.ChatListFolder_CategoryBots
+            ),
+            ChatListNodeAdditionalCategory(
+                id: AdditionalCategoryId.recent.rawValue,
+                icon: generateAvatarImage(size: CGSize(width: 40.0, height: 40.0), icon: generateTintedImage(image: UIImage(bundleImageName: "Chat List/Filters/Read"), color: .white), cornerRadius: 12.0, color: .blue),
+                smallIcon: generateAvatarImage(size: CGSize(width: 22.0, height: 22.0), icon: generateTintedImage(image: UIImage(bundleImageName: "Chat List/Filters/Read"), color: .white), iconScale: 0.6, cornerRadius: 6.0, circleCorners: true, color: .blue),
+                title: ngI18n("Nagram.ChatListFolder.CategoryRecent", presentationData.strings.baseLanguageCode)
             )
         ]
         
@@ -784,6 +811,9 @@ private func internalChatListFilterAddChatsController(context: AccountContext, f
             if filterData.categories.contains(category) {
                 selectedCategories.insert(id.rawValue)
             }
+        }
+        if includeRecent {
+            selectedCategories.insert(AdditionalCategoryId.recent.rawValue)
         }
     }
     
@@ -863,8 +893,11 @@ private func internalChatListFilterAddChatsController(context: AccountContext, f
         }
         
         var categories: ChatListFilterPeerCategories = []
+        var includeRecent = false
         for id in additionalCategoryIds {
-            if let index = categoryMapping.firstIndex(where: { $0.1.rawValue == id }) {
+            if id == AdditionalCategoryId.recent.rawValue {
+                includeRecent = true
+            } else if let index = categoryMapping.firstIndex(where: { $0.1.rawValue == id }) {
                 categories.insert(categoryMapping[index].0)
             } else {
                 assertionFailure()
@@ -888,6 +921,7 @@ private func internalChatListFilterAddChatsController(context: AccountContext, f
                 return filters
             }
             |> deliverOnMainQueue).start(next: { _ in
+                NagramSettings.shared.setRecentChatFolderEnabled(includeRecent, accountPeerId: context.account.peerId.toInt64(), filterId: filter.id)
                 controller?.dismiss()
             })
         } else {
@@ -899,7 +933,7 @@ private func internalChatListFilterAddChatsController(context: AccountContext, f
                 updatedData.excludePeers = updatedData.excludePeers.filter { !updatedData.includePeers.peers.contains($0) }
                 filter = .filter(id: id, title: title, emoticon: emoticon, data: updatedData)
             }
-            updated(filter)
+            updated(filter, includeRecent)
             controller?.dismiss()
         }
     })
@@ -1396,12 +1430,19 @@ public func chatListFilterPresetController(context: AccountContext, currentPrese
     } else {
         initialName = ChatFolderTitle(text: "", entities: [], enableAnimations: true)
     }
+    let initialIncludeRecent = initialPreset.flatMap { preset -> Bool? in
+        if preset.data?.isShared == true {
+            return false
+        }
+        return NagramSettings.shared.isRecentChatFolderEnabled(accountPeerId: context.account.peerId.toInt64(), filterId: preset.id)
+    } ?? false
     var initialState = ChatListFilterPresetControllerState(
         isExisting: initialPreset?.id != nil,
         name: initialName,
         changedName: initialPreset != nil,
         color: initialPreset?.data?.color,
         includeCategories: initialPreset?.data?.categories ?? [],
+        includeRecent: initialIncludeRecent,
         excludeMuted: initialPreset?.data?.excludeMuted ?? false,
         excludeRead: initialPreset?.data?.excludeRead ?? false,
         excludeArchived: initialPreset?.data?.excludeArchived ?? false,
@@ -1434,7 +1475,9 @@ public func chatListFilterPresetController(context: AccountContext, currentPrese
                 var includePeers = ChatListFilterIncludePeers()
                 includePeers.setPeers(state.additionallyIncludePeers)
                 let filter: ChatListFilter = .filter(id: initialPreset?.id ?? -1, title: state.name, emoticon: initialPreset?.emoticon, data: ChatListFilterData(isShared: initialPreset?.data?.isShared ?? false, hasSharedLinks: initialPreset?.data?.hasSharedLinks ?? false, categories: state.includeCategories, excludeMuted: state.excludeMuted, excludeRead: state.excludeRead, excludeArchived: state.excludeArchived, includePeers: includePeers, excludePeers: state.additionallyExcludePeers, color: state.color))
-                if let data = filter.data {
+                if state.includeRecent && state.includeCategories.isEmpty && state.additionallyIncludePeers.isEmpty && !state.excludeMuted && !state.excludeRead && state.excludeArchived {
+                    state.name = ChatFolderTitle(text: ngI18n("Nagram.ChatListFolder.CategoryRecent", presentationData.strings.baseLanguageCode), entities: [], enableAnimations: true)
+                } else if let data = filter.data {
                     switch chatListFilterType(data) {
                     case .generic:
                         state.name = initialName
@@ -1630,13 +1673,14 @@ public func chatListFilterPresetController(context: AccountContext, currentPrese
                 
                 let _ = (context.engine.peers.currentChatListFilters()
                 |> deliverOnMainQueue).start(next: { filters in
-                    let controller = internalChatListFilterAddChatsController(context: context, filter: filter, allFilters: filters, applyAutomatically: false, limit: limits.maxFolderChatsCount, premiumLimit: premiumLimits.maxFolderChatsCount, isPremium: isPremium, updated: { filter in
+                    let controller = internalChatListFilterAddChatsController(context: context, filter: filter, includeRecent: state.includeRecent, allFilters: filters, applyAutomatically: false, limit: limits.maxFolderChatsCount, premiumLimit: premiumLimits.maxFolderChatsCount, isPremium: isPremium, updated: { filter, includeRecent in
                         skipStateAnimation = true
                         updateState { state in
                             var state = state
                             state.additionallyIncludePeers = filter.data?.includePeers.peers ?? []
                             state.additionallyExcludePeers = filter.data?.excludePeers ?? []
                             state.includeCategories = filter.data?.categories ?? []
+                            state.includeRecent = includeRecent
                             return state
                         }
                     }, presentUndo: { content in
@@ -1719,7 +1763,11 @@ public func chatListFilterPresetController(context: AccountContext, currentPrese
         deleteIncludeCategory: { category in
             updateState { state in
                 var state = state
-                state.includeCategories.remove(category.category)
+                if case .recent = category {
+                    state.includeRecent = false
+                } else if let categoryValue = category.category {
+                    state.includeCategories.remove(categoryValue)
+                }
                 return state
             }
         },
@@ -2002,11 +2050,13 @@ public func chatListFilterPresetController(context: AccountContext, currentPrese
             var includePeers = ChatListFilterIncludePeers()
             includePeers.setPeers(state.additionallyIncludePeers)
             
+            var appliedFilterId: Int32?
             let _ = (context.engine.peers.updateChatListFiltersInteractively { filters in
                 var filterId = currentPreset?.id ?? -1
                 if currentPreset == nil {
                     filterId = context.engine.peers.generateNewChatListFilterId(filters: filters)
                 }
+                appliedFilterId = filterId
                 var updatedFilter: ChatListFilter = .filter(id: filterId, title: state.name, emoticon: currentPreset?.emoticon, data: ChatListFilterData(isShared: currentPreset?.data?.isShared ?? false, hasSharedLinks: currentPreset?.data?.hasSharedLinks ?? false, categories: state.includeCategories, excludeMuted: state.excludeMuted, excludeRead: state.excludeRead, excludeArchived: state.excludeArchived, includePeers: includePeers, excludePeers: state.additionallyExcludePeers, color: state.color))
                 
                 var filters = filters
@@ -2039,6 +2089,9 @@ public func chatListFilterPresetController(context: AccountContext, currentPrese
                 return filters
             }
             |> deliverOnMainQueue).start(next: { filters in
+                if let appliedFilterId {
+                    NagramSettings.shared.setRecentChatFolderEnabled(state.includeRecent, accountPeerId: context.account.peerId.toInt64(), filterId: appliedFilterId)
+                }
                 updated(filters)
                 
                 if waitForSync {
@@ -2217,7 +2270,8 @@ public func chatListFilterPresetController(context: AccountContext, currentPrese
                 var includePeers = ChatListFilterIncludePeers()
                 includePeers.setPeers(state.additionallyIncludePeers)
                 let filter: ChatListFilter = .filter(id: currentPreset.id, title: state.name, emoticon: currentPreset.emoticon, data: ChatListFilterData(isShared: currentPreset.data?.isShared ?? false, hasSharedLinks: currentPreset.data?.hasSharedLinks ?? false, categories: state.includeCategories, excludeMuted: state.excludeMuted, excludeRead: state.excludeRead, excludeArchived: state.excludeArchived, includePeers: includePeers, excludePeers: state.additionallyExcludePeers, color: state.color))
-                if currentPresetWithoutPinnedPeers != filter {
+                let currentIncludeRecent = currentData.isShared ? false : NagramSettings.shared.isRecentChatFolderEnabled(accountPeerId: context.account.peerId.toInt64(), filterId: currentId)
+                if currentPresetWithoutPinnedPeers != filter || currentIncludeRecent != state.includeRecent {
                     displaySaveAlert()
                     f(false)
                     return

--- a/submodules/ChatListUI/Sources/ChatListFilterPresetListController.swift
+++ b/submodules/ChatListUI/Sources/ChatListFilterPresetListController.swift
@@ -13,6 +13,7 @@ import ChatListFilterSettingsHeaderItem
 import PremiumUI
 import UndoUI
 import ChatFolderLinkPreviewScreen
+import NagramSettings // MARK: NAGRAM
 
 private final class ChatListFilterPresetListControllerArguments {
     let context: AccountContext
@@ -510,6 +511,7 @@ public func chatListFilterPresetListController(context: AccountContext, mode: Ch
                                 return filters
                             }
                             |> deliverOnMainQueue).start()
+                            NagramSettings.shared.setRecentChatFolderEnabled(false, accountPeerId: context.account.peerId.toInt64(), filterId: id) // MARK: NAGRAM — 清理本地最近文件夹状态
                         } else {
                             let previewScreen = ChatFolderLinkPreviewScreen(
                                 context: context,
@@ -520,7 +522,10 @@ public func chatListFilterPresetListController(context: AccountContext, mode: Ch
                                     peers: filteredPeers,
                                     alreadyMemberPeerIds: Set(),
                                     memberCounts: memberCounts
-                                )
+                                ),
+                                completion: {
+                                    NagramSettings.shared.setRecentChatFolderEnabled(false, accountPeerId: context.account.peerId.toInt64(), filterId: id) // MARK: NAGRAM — 清理本地最近文件夹状态
+                                }
                             )
                             pushControllerImpl?(previewScreen)
                         }
@@ -551,6 +556,7 @@ public func chatListFilterPresetListController(context: AccountContext, mode: Ch
                             return filters
                         }
                         |> deliverOnMainQueue).startStandalone()
+                        NagramSettings.shared.setRecentChatFolderEnabled(false, accountPeerId: context.account.peerId.toInt64(), filterId: id) // MARK: NAGRAM — 清理本地最近文件夹状态
                     })
                 ])
                 presentControllerImpl?(alertController)

--- a/submodules/ChatListUI/Sources/ChatListSearchListPaneNode.swift
+++ b/submodules/ChatListUI/Sources/ChatListSearchListPaneNode.swift
@@ -2269,10 +2269,10 @@ final class ChatListSearchListPaneNode: ASDisplayNode, ChatListSearchPaneNode {
                             guard let filter = filters.first(where: { $0.id == folderId }) else {
                                 return nil
                             }
-                            guard case let .filter(_, _, _, data) = filter else {
+                            guard case let .filter(filterId, _, _, data) = filter else {
                                 return nil
                             }
-                            return chatListFilterPredicate(filter: data, accountPeerId: context.account.peerId)
+                            return chatListFilterPredicate(filter: data, accountPeerId: context.account.peerId, includeRecentPeerIds: nagramChatListFilterRecentPeerIds(accountPeerId: context.account.peerId, filterId: filterId))
                         }
                     }
                     

--- a/submodules/ChatListUI/Sources/Node/ChatListNode.swift
+++ b/submodules/ChatListUI/Sources/Node/ChatListNode.swift
@@ -4126,8 +4126,8 @@ private func statusStringForPeerType(accountPeerId: EnginePeer.Id, strings: Pres
     
     if let chatListFilters = chatListFilters {
         let result = NSMutableAttributedString(string: "")
-        for case let .filter(_, title, _, data) in chatListFilters {
-            let predicate = chatListFilterPredicate(filter: data, accountPeerId: accountPeerId)
+        for case let .filter(id, title, _, data) in chatListFilters {
+            let predicate = chatListFilterPredicate(filter: data, accountPeerId: accountPeerId, includeRecentPeerIds: nagramChatListFilterRecentPeerIds(accountPeerId: accountPeerId, filterId: id))
             if predicate.includes(peer: peer._asPeer(), groupId: .root, isRemovedFromTotalUnreadCount: isMuted, isUnread: isUnread, isContact: isContact, messageTagSummaryResult: hasUnseenMentions) {
                 if result.length != 0 {
                     result.append(NSAttributedString(string: ", "))
@@ -4257,7 +4257,7 @@ func chatListItemTags(location: ChatListControllerLocation, accountPeerId: Engin
     var result: [ChatListItemContent.Tag] = []
     for case let .filter(id, title, _, data) in chatListFilters {
         if data.color != nil {
-            let predicate = chatListFilterPredicate(filter: data, accountPeerId: accountPeerId)
+            let predicate = chatListFilterPredicate(filter: data, accountPeerId: accountPeerId, includeRecentPeerIds: nagramChatListFilterRecentPeerIds(accountPeerId: accountPeerId, filterId: id))
             if predicate.pinnedPeerIds.contains(peer.id) || predicate.includes(peer: peer._asPeer(), groupId: .root, isRemovedFromTotalUnreadCount: isMuted, isUnread: isUnread, isContact: isContact, messageTagSummaryResult: hasUnseenMentions) {
                 result.append(ChatListItemContent.Tag(
                     id: id,

--- a/submodules/ChatListUI/Sources/Node/ChatListNodeLocation.swift
+++ b/submodules/ChatListUI/Sources/Node/ChatListNodeLocation.swift
@@ -5,6 +5,7 @@ import SwiftSignalKit
 import Display
 import TelegramUIPreferences
 import AccountContext
+import NagramSettings // MARK: NAGRAM
 
 public enum ChatListNodeLocation: Equatable {
     case initial(count: Int, filter: ChatListFilter?)
@@ -35,9 +36,10 @@ public struct ChatListNodeViewUpdate {
     }
 }
 
-public func chatListFilterPredicate(filter: ChatListFilterData, accountPeerId: EnginePeer.Id) -> ChatListFilterPredicate {
+public func chatListFilterPredicate(filter: ChatListFilterData, accountPeerId: EnginePeer.Id, includeRecentPeerIds: Set<EnginePeer.Id> = Set()) -> ChatListFilterPredicate {
     var includePeers = Set(filter.includePeers.peers)
     var excludePeers = Set(filter.excludePeers)
+    includePeers.formUnion(includeRecentPeerIds) // MARK: NAGRAM
     
     if !filter.includePeers.pinnedPeers.isEmpty {
         includePeers.subtract(filter.includePeers.pinnedPeers)
@@ -69,6 +71,15 @@ public func chatListFilterPredicate(filter: ChatListFilterData, accountPeerId: E
                 } else {
                     return false
                 }
+            }
+        }
+        if !includeRecentPeerIds.isEmpty {
+            var effectivePeerId = peer.id
+            if let associatedPeerId = peer.associatedPeerId, peer.associatedPeerOverridesIdentity {
+                effectivePeerId = associatedPeerId
+            }
+            if includeRecentPeerIds.contains(peer.id) || includeRecentPeerIds.contains(effectivePeerId) {
+                return true
             }
         }
         if !filter.categories.contains(.contacts) && isContact {
@@ -119,41 +130,84 @@ public func chatListFilterPredicate(filter: ChatListFilterData, accountPeerId: E
     })
 }
 
+public func nagramChatListFilterRecentPeerIds(accountPeerId: EnginePeer.Id, filterId: Int32) -> Set<EnginePeer.Id> {
+    let accountPeerIdValue = accountPeerId.toInt64()
+    guard NagramSettings.shared.isRecentChatFolderEnabled(accountPeerId: accountPeerIdValue, filterId: filterId)
+    else {
+        return Set()
+    }
+    return Set(NagramSettings.shared.recentChatIds(accountPeerId: accountPeerIdValue).map(EnginePeer.Id.init))
+}
+
+private func nagramRecentChatsFilterUpdates(accountPeerId: Int64, filterId: Int32) -> Signal<Void, NoError> {
+    let initial = Signal<Void, NoError>.single(Void())
+    let changes = Signal<Void, NoError> { subscriber in
+        let recentChatsObserver = NotificationCenter.default.addObserver(forName: .nagramRecentChatsDidChange, object: nil, queue: nil) { notification in
+            if let updatedAccountPeerId = notification.userInfo?["accountPeerId"] as? Int64, updatedAccountPeerId == accountPeerId {
+                subscriber.putNext(Void())
+            }
+        }
+        let folderSettingsObserver = NotificationCenter.default.addObserver(forName: .nagramRecentChatFolderSettingsDidChange, object: nil, queue: nil) { notification in
+            if let updatedAccountPeerId = notification.userInfo?["accountPeerId"] as? Int64, updatedAccountPeerId == accountPeerId,
+               let updatedFilterId = notification.userInfo?["filterId"] as? Int32,
+               updatedFilterId == filterId {
+                subscriber.putNext(Void())
+            }
+        }
+        return ActionDisposable {
+            NotificationCenter.default.removeObserver(recentChatsObserver)
+            NotificationCenter.default.removeObserver(folderSettingsObserver)
+        }
+    }
+    return initial |> then(changes)
+}
+
 public func chatListViewForLocation(chatListLocation: ChatListControllerLocation, location: ChatListNodeLocation, account: Account, shouldLoadCanMessagePeer: Bool) -> Signal<ChatListNodeViewUpdate, NoError> {
     let accountPeerId = account.peerId
     
     switch chatListLocation {
     case let .chatList(groupId):
-        let filterPredicate: ChatListFilterPredicate?
-        if let filter = location.filter, case let .filter(_, _, _, data) = filter {
-            filterPredicate = chatListFilterPredicate(filter: data, accountPeerId: account.peerId)
+        let filterPredicate: Signal<ChatListFilterPredicate?, NoError>
+        if let filter = location.filter, case let .filter(id, _, _, data) = filter {
+            let nagramAccountPeerId = account.peerId.toInt64()
+            filterPredicate = nagramRecentChatsFilterUpdates(accountPeerId: nagramAccountPeerId, filterId: id)
+            |> map { _ -> ChatListFilterPredicate? in
+                let includeRecentPeerIds = nagramChatListFilterRecentPeerIds(accountPeerId: account.peerId, filterId: id)
+                return chatListFilterPredicate(filter: data, accountPeerId: account.peerId, includeRecentPeerIds: includeRecentPeerIds)
+            }
         } else {
-            filterPredicate = nil
+            filterPredicate = .single(nil)
         }
         
         switch location {
         case let .initial(count, _):
-            let signal: Signal<(ChatListView, ViewUpdateType), NoError>
-            signal = account.viewTracker.tailChatListView(groupId: groupId._asGroup(), filterPredicate: filterPredicate, count: count, shouldLoadCanMessagePeer: shouldLoadCanMessagePeer)
-            return signal
-            |> map { view, updateType -> ChatListNodeViewUpdate in
-                return ChatListNodeViewUpdate(list: EngineChatList(view, accountPeerId: accountPeerId), type: updateType, scrollPosition: nil)
+            return filterPredicate
+            |> mapToSignal { filterPredicate -> Signal<ChatListNodeViewUpdate, NoError> in
+                let signal: Signal<(ChatListView, ViewUpdateType), NoError>
+                signal = account.viewTracker.tailChatListView(groupId: groupId._asGroup(), filterPredicate: filterPredicate, count: count, shouldLoadCanMessagePeer: shouldLoadCanMessagePeer)
+                return signal
+                |> map { view, updateType -> ChatListNodeViewUpdate in
+                    return ChatListNodeViewUpdate(list: EngineChatList(view, accountPeerId: accountPeerId), type: updateType, scrollPosition: nil)
+                }
             }
         case let .navigation(index, _):
             guard case let .chatList(index) = index else {
                 return .never()
             }
-            var first = true
-            return account.viewTracker.aroundChatListView(groupId: groupId._asGroup(), filterPredicate: filterPredicate, index: index, count: 80, shouldLoadCanMessagePeer: shouldLoadCanMessagePeer)
-            |> map { view, updateType -> ChatListNodeViewUpdate in
-                let genericType: ViewUpdateType
-                if first {
-                    first = false
-                    genericType = ViewUpdateType.UpdateVisible
-                } else {
-                    genericType = updateType
+            return filterPredicate
+            |> mapToSignal { filterPredicate -> Signal<ChatListNodeViewUpdate, NoError> in
+                var first = true
+                return account.viewTracker.aroundChatListView(groupId: groupId._asGroup(), filterPredicate: filterPredicate, index: index, count: 80, shouldLoadCanMessagePeer: shouldLoadCanMessagePeer)
+                |> map { view, updateType -> ChatListNodeViewUpdate in
+                    let genericType: ViewUpdateType
+                    if first {
+                        first = false
+                        genericType = ViewUpdateType.UpdateVisible
+                    } else {
+                        genericType = updateType
+                    }
+                    return ChatListNodeViewUpdate(list: EngineChatList(view, accountPeerId: accountPeerId), type: genericType, scrollPosition: nil)
                 }
-                return ChatListNodeViewUpdate(list: EngineChatList(view, accountPeerId: accountPeerId), type: genericType, scrollPosition: nil)
             }
         case let .scroll(index, sourceIndex, scrollPosition, animated, _):
             guard case let .chatList(index) = index else {
@@ -162,18 +216,21 @@ public func chatListViewForLocation(chatListLocation: ChatListControllerLocation
             
             let directionHint: ListViewScrollToItemDirectionHint = sourceIndex > .chatList(index) ? .Down : .Up
             let chatScrollPosition: ChatListNodeViewScrollPosition = .index(index: index, position: scrollPosition, directionHint: directionHint, animated: animated)
-            var first = true
-            return account.viewTracker.aroundChatListView(groupId: groupId._asGroup(), filterPredicate: filterPredicate, index: index, count: 80, shouldLoadCanMessagePeer: shouldLoadCanMessagePeer)
-            |> map { view, updateType -> ChatListNodeViewUpdate in
-                let genericType: ViewUpdateType
-                let scrollPosition: ChatListNodeViewScrollPosition? = first ? chatScrollPosition : nil
-                if first {
-                    first = false
-                    genericType = ViewUpdateType.UpdateVisible
-                } else {
-                    genericType = updateType
+            return filterPredicate
+            |> mapToSignal { filterPredicate -> Signal<ChatListNodeViewUpdate, NoError> in
+                var first = true
+                return account.viewTracker.aroundChatListView(groupId: groupId._asGroup(), filterPredicate: filterPredicate, index: index, count: 80, shouldLoadCanMessagePeer: shouldLoadCanMessagePeer)
+                |> map { view, updateType -> ChatListNodeViewUpdate in
+                    let genericType: ViewUpdateType
+                    let scrollPosition: ChatListNodeViewScrollPosition? = first ? chatScrollPosition : nil
+                    if first {
+                        first = false
+                        genericType = ViewUpdateType.UpdateVisible
+                    } else {
+                        genericType = updateType
+                    }
+                    return ChatListNodeViewUpdate(list: EngineChatList(view, accountPeerId: accountPeerId), type: genericType, scrollPosition: scrollPosition)
                 }
-                return ChatListNodeViewUpdate(list: EngineChatList(view, accountPeerId: accountPeerId), type: genericType, scrollPosition: scrollPosition)
             }
         }
     case let .forum(peerId):

--- a/submodules/ChatListUI/Sources/Node/ChatListNodeLocation.swift
+++ b/submodules/ChatListUI/Sources/Node/ChatListNodeLocation.swift
@@ -142,12 +142,12 @@ public func nagramChatListFilterRecentPeerIds(accountPeerId: EnginePeer.Id, filt
 private func nagramRecentChatsFilterUpdates(accountPeerId: Int64, filterId: Int32) -> Signal<Void, NoError> {
     let initial = Signal<Void, NoError>.single(Void())
     let changes = Signal<Void, NoError> { subscriber in
-        let recentChatsObserver = NotificationCenter.default.addObserver(forName: .nagramRecentChatsDidChange, object: nil, queue: nil) { notification in
+        let recentChatsObserver = NotificationCenter.default.addObserver(forName: .nagramRecentChatsDidChange, object: nil, queue: .main) { notification in
             if let updatedAccountPeerId = notification.userInfo?["accountPeerId"] as? Int64, updatedAccountPeerId == accountPeerId {
                 subscriber.putNext(Void())
             }
         }
-        let folderSettingsObserver = NotificationCenter.default.addObserver(forName: .nagramRecentChatFolderSettingsDidChange, object: nil, queue: nil) { notification in
+        let folderSettingsObserver = NotificationCenter.default.addObserver(forName: .nagramRecentChatFolderSettingsDidChange, object: nil, queue: .main) { notification in
             if let updatedAccountPeerId = notification.userInfo?["accountPeerId"] as? Int64, updatedAccountPeerId == accountPeerId,
                let updatedFilterId = notification.userInfo?["filterId"] as? Int32,
                updatedFilterId == filterId {

--- a/submodules/TelegramUI/Components/PeerInfo/PeerInfoScreen/Sources/PeerInfoScreen.swift
+++ b/submodules/TelegramUI/Components/PeerInfo/PeerInfoScreen/Sources/PeerInfoScreen.swift
@@ -6946,6 +6946,82 @@ public final class PeerInfoScreenImpl: ViewController, PeerInfoScreen, KeyShortc
         })
     }
     
+    // MARK: NAGRAM — 最近会话返回菜单
+    public static func displayNagramRecentChatsMenu(context: AccountContext, parentController: ViewController, sourceView: UIView, navigationController: NavigationController, gesture: ContextGesture, useBackAnimation: Bool, fallback: @escaping () -> Void) {
+        guard NagramSettings.shared.recentChatsEnabled else {
+            fallback()
+            return
+        }
+        
+        let peerIds = NagramSettings.shared.recentChatIds(accountPeerId: context.account.peerId.toInt64(), limit: 25).map { EnginePeer.Id($0) }
+        guard !peerIds.isEmpty else {
+            fallback()
+            return
+        }
+        
+        let peerMap = EngineDataMap(
+            Set(peerIds).map(TelegramEngine.EngineData.Item.Peer.Peer.init)
+        )
+        let _ = (context.engine.data.get(
+            peerMap
+        )
+        |> deliverOnMainQueue).startStandalone(next: { [weak parentController, weak sourceView, weak navigationController] peerMap in
+            guard let parentController, let sourceView else {
+                return
+            }
+            
+            let presentationData = context.sharedContext.currentPresentationData.with { $0 }
+            let avatarSize = CGSize(width: 28.0, height: 28.0)
+            var items: [ContextMenuItem] = []
+            
+            for peerId in peerIds {
+                guard let maybePeer = peerMap[peerId], let peer = maybePeer else {
+                    continue
+                }
+                
+                let isSavedMessages = peer.id == context.account.peerId
+                let title: String
+                let iconSource: ContextMenuActionItemIconSource?
+                if isSavedMessages {
+                    title = presentationData.strings.DialogList_SavedMessages
+                    iconSource = nil
+                } else {
+                    title = peer.displayTitle(strings: presentationData.strings, displayOrder: presentationData.nameDisplayOrder)
+                    iconSource = ContextMenuActionItemIconSource(size: avatarSize, signal: peerAvatarCompleteImage(account: context.account, peer: peer, size: avatarSize))
+                }
+                
+                items.append(.action(ContextMenuActionItem(text: title, icon: { _ in
+                    if isSavedMessages {
+                        return generateAvatarImage(size: avatarSize, icon: savedMessagesIcon, iconScale: 0.5, color: .blue)
+                    }
+                    return nil
+                }, iconSource: iconSource, action: { _, f in
+                    f(.default)
+                    
+                    guard let navigationController else {
+                        return
+                    }
+                    
+                    context.sharedContext.navigateToChatController(NavigateToChatControllerParams(
+                        navigationController: navigationController,
+                        context: context,
+                        chatLocation: .peer(peer),
+                        useBackAnimation: useBackAnimation,
+                        animated: true
+                    ))
+                })))
+            }
+            
+            if items.isEmpty {
+                fallback()
+                return
+            }
+            
+            let contextController = makeContextController(presentationData: presentationData, source: .reference(PeerInfoControllerContextReferenceContentSource(controller: parentController, sourceView: sourceView, insets: UIEdgeInsets(), contentInsets: UIEdgeInsets(top: 0.0, left: -15.0, bottom: 0.0, right: -15.0))), items: .single(ContextController.Items(content: .list(items))), gesture: gesture)
+            parentController.presentInGlobalOverlay(contextController)
+        })
+    }
+    
     public static func displayChatNavigationMenu(context: AccountContext, chatNavigationStack: [ChatNavigationStackItem], nextFolderId: Int32?, parentController: ViewController, backButtonView: UIView, navigationController: NavigationController, gesture: ContextGesture) {
         let peerMap = EngineDataMap(
             Set(chatNavigationStack.map(\.peerId)).map(TelegramEngine.EngineData.Item.Peer.Peer.init)
@@ -7052,7 +7128,8 @@ public final class PeerInfoScreenImpl: ViewController, PeerInfoScreen, KeyShortc
             chatNavigationStack = summary.peerNavigationItems.filter({ $0 != ChatNavigationStackItem(peerId: self.peerId, threadId: self.chatLocation.threadId) })
         }
         
-        if !chatNavigationStack.isEmpty, let backButtonNode = self.navigationBar?.backButtonNode as? ContextControllerSourceNode {
+        let hasNagramRecentChats = NagramSettings.shared.recentChatsEnabled && !NagramSettings.shared.recentChatIds(accountPeerId: self.context.account.peerId.toInt64(), limit: 1).isEmpty // MARK: NAGRAM
+        if (!chatNavigationStack.isEmpty || hasNagramRecentChats), let backButtonNode = self.navigationBar?.backButtonNode as? ContextControllerSourceNode {
             backButtonNode.isGestureEnabled = true
             backButtonNode.activated = { [weak self] gesture, _ in
                 guard let strongSelf = self, let backButtonNode = strongSelf.navigationBar?.backButtonNode, let navigationController = strongSelf.navigationController as? NavigationController else {
@@ -7060,14 +7137,29 @@ public final class PeerInfoScreenImpl: ViewController, PeerInfoScreen, KeyShortc
                     return
                 }
                 
-                PeerInfoScreenImpl.displayChatNavigationMenu(
+                let fallback = {
+                    if chatNavigationStack.isEmpty {
+                        gesture.cancel()
+                    } else {
+                        PeerInfoScreenImpl.displayChatNavigationMenu(
+                            context: strongSelf.context,
+                            chatNavigationStack: chatNavigationStack,
+                            nextFolderId: nil,
+                            parentController: strongSelf,
+                            backButtonView: backButtonNode.view,
+                            navigationController: navigationController,
+                            gesture: gesture
+                        )
+                    }
+                }
+                PeerInfoScreenImpl.displayNagramRecentChatsMenu(
                     context: strongSelf.context,
-                    chatNavigationStack: chatNavigationStack,
-                    nextFolderId: nil,
                     parentController: strongSelf,
-                    backButtonView: backButtonNode.view,
+                    sourceView: backButtonNode.view,
                     navigationController: navigationController,
-                    gesture: gesture
+                    gesture: gesture,
+                    useBackAnimation: true,
+                    fallback: fallback
                 )
             }
         }

--- a/submodules/TelegramUI/Components/PeerInfo/PeerInfoScreen/Sources/PeerInfoScreen.swift
+++ b/submodules/TelegramUI/Components/PeerInfo/PeerInfoScreen/Sources/PeerInfoScreen.swift
@@ -6947,13 +6947,18 @@ public final class PeerInfoScreenImpl: ViewController, PeerInfoScreen, KeyShortc
     }
     
     // MARK: NAGRAM — 最近会话返回菜单
-    public static func displayNagramRecentChatsMenu(context: AccountContext, parentController: ViewController, sourceView: UIView, navigationController: NavigationController, gesture: ContextGesture, useBackAnimation: Bool, fallback: @escaping () -> Void) {
+    public static func displayNagramRecentChatsMenu(context: AccountContext, parentController: ViewController, sourceView: UIView, navigationController: NavigationController, gesture: ContextGesture, useBackAnimation: Bool, excludePeerId: EnginePeer.Id?, fallback: @escaping () -> Void) {
         guard NagramSettings.shared.recentChatsEnabled else {
             fallback()
             return
         }
         
-        let peerIds = NagramSettings.shared.recentChatIds(accountPeerId: context.account.peerId.toInt64(), limit: 25).map { EnginePeer.Id($0) }
+        let peerIds = Array(NagramSettings.shared.recentChatIds(accountPeerId: context.account.peerId.toInt64()).map(EnginePeer.Id.init).filter { peerId in
+            if let excludePeerId {
+                return peerId != excludePeerId
+            }
+            return true
+        }.prefix(25))
         guard !peerIds.isEmpty else {
             fallback()
             return
@@ -7159,6 +7164,7 @@ public final class PeerInfoScreenImpl: ViewController, PeerInfoScreen, KeyShortc
                     navigationController: navigationController,
                     gesture: gesture,
                     useBackAnimation: true,
+                    excludePeerId: strongSelf.peerId,
                     fallback: fallback
                 )
             }

--- a/submodules/TelegramUI/Sources/ChatController.swift
+++ b/submodules/TelegramUI/Sources/ChatController.swift
@@ -15,6 +15,7 @@ import DeviceAccess
 import TextFormat
 import TelegramBaseController
 import AccountContext
+import NagramSettings // MARK: NAGRAM
 import TelegramStringFormatting
 import OverlayStatusController
 import DeviceLocationManager
@@ -666,6 +667,9 @@ public final class ChatControllerImpl: TelegramBaseController, ChatController, G
         self.currentChatListFilter = chatListFilter
         self.chatNavigationStack = chatNavigationStack
         self.customChatNavigationStack = customChatNavigationStack
+        if let peerId = chatLocation.peerId { // MARK: NAGRAM — 记录进入的会话
+            NagramSettings.shared.addRecentChatId(peerId.toInt64(), accountPeerId: context.account.peerId.toInt64())
+        }
         
         self.forcedTheme = params?.forcedTheme
         self.forcedNavigationBarTheme = params?.forcedNavigationBarTheme
@@ -7450,7 +7454,8 @@ public final class ChatControllerImpl: TelegramBaseController, ChatController, G
             }
         }
         
-        if !chatNavigationStack.isEmpty, let backButtonNode = self.chatDisplayNode.navigationBar?.backButtonNode as? ContextControllerSourceNode {
+        let hasNagramRecentChats = NagramSettings.shared.recentChatsEnabled && !NagramSettings.shared.recentChatIds(accountPeerId: self.context.account.peerId.toInt64(), limit: 1).isEmpty // MARK: NAGRAM
+        if (!chatNavigationStack.isEmpty || hasNagramRecentChats), let backButtonNode = self.chatDisplayNode.navigationBar?.backButtonNode as? ContextControllerSourceNode {
             backButtonNode.isGestureEnabled = true
             backButtonNode.activated = { [weak self] gesture, _ in
                 guard let strongSelf = self, let backButtonNode = strongSelf.chatDisplayNode.navigationBar?.backButtonNode, let navigationController = strongSelf.effectiveNavigationController else {
@@ -7458,14 +7463,29 @@ public final class ChatControllerImpl: TelegramBaseController, ChatController, G
                     return
                 }
                 let nextFolderId: Int32? = strongSelf.currentChatListFilter
-                PeerInfoScreenImpl.displayChatNavigationMenu(
+                let fallback = {
+                    if chatNavigationStack.isEmpty {
+                        gesture.cancel()
+                    } else {
+                        PeerInfoScreenImpl.displayChatNavigationMenu(
+                            context: strongSelf.context,
+                            chatNavigationStack: chatNavigationStack,
+                            nextFolderId: nextFolderId,
+                            parentController: strongSelf,
+                            backButtonView: backButtonNode.view,
+                            navigationController: navigationController,
+                            gesture: gesture
+                        )
+                    }
+                }
+                PeerInfoScreenImpl.displayNagramRecentChatsMenu(
                     context: strongSelf.context,
-                    chatNavigationStack: chatNavigationStack,
-                    nextFolderId: nextFolderId,
                     parentController: strongSelf,
-                    backButtonView: backButtonNode.view,
+                    sourceView: backButtonNode.view,
                     navigationController: navigationController,
-                    gesture: gesture
+                    gesture: gesture,
+                    useBackAnimation: true,
+                    fallback: fallback
                 )
             }
         }

--- a/submodules/TelegramUI/Sources/ChatController.swift
+++ b/submodules/TelegramUI/Sources/ChatController.swift
@@ -7485,6 +7485,7 @@ public final class ChatControllerImpl: TelegramBaseController, ChatController, G
                     navigationController: navigationController,
                     gesture: gesture,
                     useBackAnimation: true,
+                    excludePeerId: strongSelf.chatLocation.peerId,
                     fallback: fallback
                 )
             }

--- a/submodules/TelegramUI/Sources/ChatControllerContentData.swift
+++ b/submodules/TelegramUI/Sources/ChatControllerContentData.swift
@@ -1151,7 +1151,11 @@ extension ChatControllerImpl {
                             let accountPeerId = context.account.peerId
                             strongSelf.nextChannelToReadDisposable = (combineLatest(queue: .mainQueue(),
                                 context.engine.peers.getNextUnreadChannel(peerId: channel.id, chatListFilterId: currentChatListFilter, getFilterPredicate: { data in
-                                    return chatListFilterPredicate(filter: data, accountPeerId: accountPeerId)
+                                    if let currentChatListFilter {
+                                        return chatListFilterPredicate(filter: data, accountPeerId: accountPeerId, includeRecentPeerIds: nagramChatListFilterRecentPeerIds(accountPeerId: accountPeerId, filterId: currentChatListFilter))
+                                    } else {
+                                        return chatListFilterPredicate(filter: data, accountPeerId: accountPeerId)
+                                    }
                                 }),
                                 ApplicationSpecificNotice.getNextChatSuggestionTip(accountManager: context.sharedContext.accountManager)
                             )

--- a/submodules/TelegramUI/Sources/NavigateToChatController.swift
+++ b/submodules/TelegramUI/Sources/NavigateToChatController.swift
@@ -4,6 +4,7 @@ import Display
 import SwiftSignalKit
 import TelegramCore
 import AccountContext
+import NagramSettings // MARK: NAGRAM
 import GalleryUI
 import InstantPageUI
 import ChatListUI
@@ -80,6 +81,8 @@ public func navigateToChatControllerImpl(_ params: NavigateToChatControllerParam
             })
             return
         }
+        
+        NagramSettings.shared.addRecentChatId(params.chatLocation.peerId.toInt64(), accountPeerId: params.context.account.peerId.toInt64()) // MARK: NAGRAM — 记录导航进入的会话
         
         if case let .peer(peer) = params.chatLocation, case let .channel(channel) = peer, channel.flags.contains(.isForum), !viewForumAsMessages {
             for controller in params.navigationController.viewControllers.reversed() {
@@ -493,6 +496,7 @@ public func chatControllerForForumThreadImpl(context: AccountContext, peerId: En
 }
 
 public func navigateToForumChannelImpl(context: AccountContext, peerId: EnginePeer.Id, navigationController: NavigationController) {
+    NagramSettings.shared.addRecentChatId(peerId.toInt64(), accountPeerId: context.account.peerId.toInt64()) // MARK: NAGRAM — 记录进入 forum 话题列表
     let controller = ChatListControllerImpl(context: context, location: .forum(peerId: peerId), controlsHistoryPreload: false, enableDebugActions: false)
     controller.navigationPresentation = .master
     navigationController.pushViewController(controller)


### PR DESCRIPTION
Fixes #25

## Summary

Add Nagram-style quick return to recent chats and a local Recent chat type for chat folders.

## Requirements

- Record chats entered by the user for quick return.
- Feature name: Quick Return to Recent Chats / 快速返回最近会话.
- Add a Nagram setting switch to control the quick-return menu.
- Add Recent as a selectable chat type in chat folder configuration.
- If a folder has Recent enabled and a chat comes from the recent list, removing that chat from the folder removes it from the recent list only, without changing folder configuration.

## Implementation

- Added account-scoped recent chat storage in `Nagram/Settings/NagramRecentChats.swift`, stored in `UserDefaults` and refreshed through local notifications.
- Added `NagramSettings.recentChatsEnabled` and localized setting text.
- Record entered chats from `ChatController` and `NavigateToChatController`, including forum topic list entry.
- Long-pressing the chat back button can show the recent chat menu before falling back to the existing navigation stack menu.
- Long-pressing the Chats tab can show recent chats before falling back to the existing tab menu.
- Chat folder edit UI now includes a local Recent category, stored in Nagram settings rather than Telegram's native filter data.
- Chat list folder predicates merge recent peer ids into the include set and refresh when recent chats or folder settings change.
- Removing a recent chat from a Recent-enabled folder deletes only the recent record and preserves the folder config.

## Usage

1. Open Nagram settings and enable `快速返回最近会话`.
2. Open chats normally; the app records the latest entered chats per account. Current limit: 50 records.
3. Long-press the chat back button to jump to a recent chat.
4. Long-press the Chats tab on the home screen to view recent chats.
5. In chat folder editing, select the `最近` chat type to include recent chats in that folder.
6. In a Recent-enabled folder, long-press a recent chat and choose remove from folder to remove it from the recent list only.

## Verification

- Full device `debug_arm64` build passed: `Build completed successfully`.
- Device install succeeded for `xyz.nextalone.nagram`.
- Launch check was blocked by the device lock state: `Unable to launch xyz.nextalone.nagram because the device was not, or could not be, unlocked`.