### PR TITLE
[codex] Support nasettings deep links

### DIFF
--- a/Nagram/SettingsUI/BUILD
+++ b/Nagram/SettingsUI/BUILD
@@ -20,6 +20,7 @@ swift_library(
         "//submodules/AccountContext:AccountContext",
         "//submodules/TelegramCore:TelegramCore",
         "//submodules/TelegramUIPreferences:TelegramUIPreferences",
+        "//submodules/UndoUI:UndoUI",
         "//Nagram/Settings:NagramSettings",
         "//Nagram/Strings:NagramStrings",
         "//Nagram/SettingsSignal:NagramSettingsSignal",

--- a/Nagram/SettingsUI/NagramSettingsController.swift
+++ b/Nagram/SettingsUI/NagramSettingsController.swift
@@ -10,6 +10,8 @@ import SwiftSignalKit
 import TelegramCore
 import TelegramPresentationData
 import TelegramUIPreferences
+import UIKit
+import UndoUI
 
 // MARK: NAGRAM — 增强设置页 UI。
 // 顶部 3 段(通用/消息/其他)用 ItemListControllerTitle.sectionControl;段内用 section header 分层。
@@ -30,6 +32,29 @@ private enum NagramTab: Int32, CaseIterable {
         case .other: return "Nagram.Tab.Other"
         }
     }
+
+    var deepLinkSection: String {
+        switch self {
+        case .general: return "general"
+        case .chat: return "chat"
+        case .other: return "other"
+        }
+    }
+}
+
+private final class NagramSettingsRowTag: ItemListItemTag {
+    let index: Int
+
+    init(index: Int) {
+        self.index = index
+    }
+
+    func isEqual(to other: ItemListItemTag) -> Bool {
+        if let other = other as? NagramSettingsRowTag {
+            return self.index == other.index
+        }
+        return false
+    }
 }
 
 // 行类型:开关 / 单选(disclosure + ActionSheet) / 行内滑杆。
@@ -39,6 +64,227 @@ private enum NagramRow {
     case choice(titleKey: String, prefix: String, options: [String], current: () -> String, set: (String) -> Void)
     case slider(minValue: Int32, maxValue: Int32, get: () -> Int32, set: (Int32) -> Void)
     case navigation(titleKey: String, action: () -> Void)
+}
+
+private struct NagramDeepLinkRequest {
+    let section: String?
+    let row: String?
+}
+
+private struct NagramDeepLinkTarget {
+    let tab: NagramTab
+    let rowIndex: Int?
+}
+
+private func normalizedNagramDeepLinkToken(_ value: String) -> String {
+    return String(value.lowercased().filter { $0.isLetter || $0.isNumber })
+}
+
+private func nagramRowTitleKey(_ row: NagramRow) -> String {
+    switch row {
+    case let .toggle(titleKey, _, _):
+        return titleKey
+    case let .toggleWithEnabled(titleKey, _, _, _, _):
+        return titleKey
+    case let .choice(titleKey, _, _, _, _):
+        return titleKey
+    case .slider:
+        return "Nagram.StickerSize"
+    case let .navigation(titleKey, _):
+        return titleKey
+    }
+}
+
+private func nagramRowDeepLinkAliases(titleKey: String) -> [String] {
+    switch titleKey {
+    case "Nagram.HideTabBar":
+        return ["MainTabsStyle", "TabStyle"]
+    case "Nagram.HideTabBarCalls":
+        return ["HideCallsTab", "HideCallTab"]
+    case "Nagram.HideTabBarContacts":
+        return ["HideContactsTab", "HideContactTab"]
+    case "Nagram.HideTabBarChatList":
+        return ["HideChatsTab", "HideChatListTab"]
+    case "Nagram.HideTabBarSettings":
+        return ["HideSettingsTab"]
+    case "Nagram.ShowTabBarSearch":
+        return ["ShowSearchTab", "SearchTab"]
+    case "Nagram.HideStories":
+        return ["DisableStories"]
+    case "Nagram.DisableGalleryCamera":
+        return ["DisableInAppCamera", "inappCamera"]
+    case "Nagram.DisableGalleryCameraPreview":
+        return ["DisableCameraPreview"]
+    case "Nagram.DownloadSpeedBoost":
+        return ["enhancedFileLoader", "downloadSpeedBoost"]
+    case "Nagram.UploadSpeedBoost":
+        return ["uploadSpeedBoost"]
+    case "Nagram.SecondsInMessages":
+        return ["showSeconds", "ShowSeconds"]
+    case "Nagram.HideReactions":
+        return ["disableReactionsWhenSelecting", "HideReactions"]
+    case "Nagram.HideChannelBottomButton":
+        return ["HideChannelBottomButton"]
+    case "Nagram.HideSponsoredMessages":
+        return ["HideSponsoredMessages", "DisableSponsoredMessages"]
+    case "Nagram.PanguOnReceiving":
+        return ["PanguOnReceiving", "PanguOnRecv", "PanguReceiving"]
+    case "Nagram.PanguOnSending":
+        return ["PanguOnSending", "PanguSending"]
+    case "Nagram.PanguOnEditing":
+        return ["PanguOnEditing", "PanguEditing"]
+    case "Nagram.MessageMenu":
+        return ["MessageMenu", "DisableActionBarButton"]
+    case "Nagram.StickerSize":
+        return ["stickerSize"]
+    case "Nagram.StickerTimestamp":
+        return ["StickerTimestamp", "StickerTime"]
+    case "Nagram.DisableSendAsButton":
+        return ["hideSendAsChannel", "DisableSendAsButton"]
+    case "Nagram.SendWithReturnKey":
+        return ["SendWithReturnKey", "ReturnKeySend"]
+    case "Nagram.HideRecordingButton":
+        return ["HideRecordingButton", "HideRecordButton"]
+    case "Nagram.RecentChats":
+        return ["RecentChats", "recent_dialogs", "ShowRecentChatsInSidebar"]
+    case "Nagram.ChatListSwipeAction":
+        return ["ChatListSwipeAction"]
+    case "Nagram.DisableScrollToNextChannel":
+        return ["DisableScrollToNextChannel"]
+    case "Nagram.DisableScrollToNextTopic":
+        return ["DisableScrollToNextTopic"]
+    case "Nagram.VideoPIPSwipeUp":
+        return ["VideoPIPSwipeUp", "VideoPIPSwipeDirection"]
+    case "Nagram.ShowProfileId":
+        return ["ShowProfileId", "ShowId", "ShowIdAndDc"]
+    case "Nagram.ShowDC":
+        return ["ShowDC", "ShowDataCenter", "ShowIdAndDc"]
+    case "Nagram.ShowRegDate":
+        return ["ShowRegDate", "RegistrationDate"]
+    case "Nagram.ConfirmCalls":
+        return ["AskBeforeCalling", "ConfirmCalls"]
+    case "Nagram.DisableFiltering":
+        return ["DisableFiltering"]
+    case "Nagram.ForceCopy":
+        return ["ForceCopy", "ForceCopyEnabled"]
+    default:
+        return []
+    }
+}
+
+private func nagramRowDeepLinkTokens(_ row: NagramRow) -> [String] {
+    let titleKey = nagramRowTitleKey(row)
+    var values = [titleKey]
+    if titleKey.hasPrefix("Nagram.") {
+        values.append(String(titleKey.dropFirst("Nagram.".count)))
+    }
+    values.append(contentsOf: nagramRowDeepLinkAliases(titleKey: titleKey))
+    return values.map(normalizedNagramDeepLinkToken)
+}
+
+private func nagramRowDeepLinkKey(_ row: NagramRow) -> String {
+    let titleKey = nagramRowTitleKey(row)
+    if titleKey.hasPrefix("Nagram.") {
+        return String(titleKey.dropFirst("Nagram.".count))
+    }
+    return titleKey
+}
+
+private func nagramSettingsDeepLink(tab: NagramTab, row: NagramRow) -> String {
+    var components = URLComponents()
+    components.scheme = "https"
+    components.host = "t.me"
+    components.path = "/nasettings/\(tab.deepLinkSection)"
+    components.queryItems = [
+        URLQueryItem(name: "r", value: nagramRowDeepLinkKey(row))
+    ]
+    return components.url?.absoluteString ?? "https://t.me/nasettings/\(tab.deepLinkSection)?r=\(nagramRowDeepLinkKey(row))"
+}
+
+private func nagramTabForDeepLinkSection(_ section: String?) -> NagramTab? {
+    guard let section else {
+        return nil
+    }
+    switch normalizedNagramDeepLinkToken(section) {
+    case "general", "g", "interface", "camera", "network":
+        return .general
+    case "chat", "chats", "c", "message", "messages", "stickers", "gesture":
+        return .chat
+    case "other", "o", "account", "a", "about", "privacy", "profile", "calls", "experimental", "e", "emoji":
+        return .other
+    default:
+        return nil
+    }
+}
+
+private func parseNagramDeepLinkRequest(_ deepLinkPath: String?) -> NagramDeepLinkRequest? {
+    guard var raw = deepLinkPath?.trimmingCharacters(in: .whitespacesAndNewlines), !raw.isEmpty else {
+        return nil
+    }
+    if raw.lowercased().hasPrefix("nagram") {
+        raw = String(raw.dropFirst("nagram".count))
+        if raw.hasPrefix("/") {
+            raw = String(raw.dropFirst())
+        }
+    }
+
+    let urlString: String
+    if raw.isEmpty {
+        urlString = "nagram://settings"
+    } else if raw.hasPrefix("?") {
+        urlString = "nagram://settings\(raw)"
+    } else {
+        urlString = "nagram://settings/\(raw)"
+    }
+
+    guard let components = URLComponents(string: urlString) else {
+        return nil
+    }
+
+    let pathComponents = components.path.split(separator: "/").map(String.init)
+    let section = pathComponents.first
+    var row: String?
+    for item in components.queryItems ?? [] {
+        switch item.name.lowercased() {
+        case "r", "row":
+            if let value = item.value, !value.isEmpty {
+                row = value
+            }
+        default:
+            break
+        }
+    }
+    return NagramDeepLinkRequest(section: section, row: row)
+}
+
+private func nagramDeepLinkTarget(deepLinkPath: String?, groups: [NagramGroup]) -> NagramDeepLinkTarget {
+    let request = parseNagramDeepLinkRequest(deepLinkPath)
+    var selectedTab = nagramTabForDeepLinkSection(request?.section) ?? .general
+    var rowIndex: Int?
+
+    let rowCandidates = [request?.row, request?.section].compactMap { value -> String? in
+        guard let value, nagramTabForDeepLinkSection(value) == nil else {
+            return nil
+        }
+        return normalizedNagramDeepLinkToken(value)
+    }
+
+    if !rowCandidates.isEmpty {
+        var globalRowIndex = 0
+        scan: for group in groups {
+            for row in group.rows {
+                let tokens = nagramRowDeepLinkTokens(row)
+                if rowCandidates.contains(where: { tokens.contains($0) }) {
+                    selectedTab = group.tab
+                    rowIndex = globalRowIndex
+                    break scan
+                }
+                globalRowIndex += 1
+            }
+        }
+    }
+
+    return NagramDeepLinkTarget(tab: selectedTab, rowIndex: rowIndex)
 }
 
 private struct NagramGroup {
@@ -140,10 +386,13 @@ private final class NagramSettingsArguments {
     let toggle: (Int, Bool) -> Void
     let disclosureAction: (Int) -> Void
     let sliderUpdated: (Int, Int32) -> Void
-    init(toggle: @escaping (Int, Bool) -> Void, disclosureAction: @escaping (Int) -> Void, sliderUpdated: @escaping (Int, Int32) -> Void) {
+    let copyDeepLink: (Int) -> Void
+
+    init(toggle: @escaping (Int, Bool) -> Void, disclosureAction: @escaping (Int) -> Void, sliderUpdated: @escaping (Int, Int32) -> Void, copyDeepLink: @escaping (Int) -> Void) {
         self.toggle = toggle
         self.disclosureAction = disclosureAction
         self.sliderUpdated = sliderUpdated
+        self.copyDeepLink = copyDeepLink
     }
 }
 
@@ -198,6 +447,19 @@ private enum NagramSettingsEntry: ItemListNodeEntry {
         return lhs.stableId < rhs.stableId
     }
 
+    var tag: ItemListItemTag? {
+        switch self {
+        case let .toggle(_, _, _, _, _, _, index):
+            return NagramSettingsRowTag(index: index)
+        case let .disclosure(_, _, _, _, index):
+            return NagramSettingsRowTag(index: index)
+        case let .slider(_, _, _, _, _, index):
+            return NagramSettingsRowTag(index: index)
+        default:
+            return nil
+        }
+    }
+
     func item(presentationData: ItemListPresentationData, arguments: Any) -> ListViewItem {
         let arguments = arguments as! NagramSettingsArguments
         switch self {
@@ -206,22 +468,28 @@ private enum NagramSettingsEntry: ItemListNodeEntry {
         case let .toggle(_, section, title, value, enabled, enableInteractiveChanges, index):
             return ItemListSwitchItem(presentationData: presentationData, systemStyle: .glass, title: title, value: value, enableInteractiveChanges: enableInteractiveChanges, enabled: enabled, sectionId: section, style: .blocks, updated: { value in
                 arguments.toggle(index, value)
-            })
+            }, longTapAction: {
+                arguments.copyDeepLink(index)
+            }, tag: self.tag)
         case let .disclosure(_, section, title, label, index):
             return ItemListDisclosureItem(presentationData: presentationData, systemStyle: .glass, title: title, label: label, sectionId: section, style: .blocks, action: {
                 arguments.disclosureAction(index)
-            })
+            }, longTapAction: {
+                arguments.copyDeepLink(index)
+            }, tag: self.tag)
         case let .slider(_, section, minValue, maxValue, value, index):
             return NagramSliderItem(theme: presentationData.theme, minValue: minValue, maxValue: maxValue, value: value, sectionId: section, updated: { newValue in
                 arguments.sliderUpdated(index, newValue)
-            })
+            }, longTapAction: {
+                arguments.copyDeepLink(index)
+            }, tag: self.tag)
         case let .footer(_, section, text):
             return ItemListTextItem(presentationData: presentationData, text: .plain(text), sectionId: section)
         }
     }
 }
 
-public func nagramSettingsController(context: AccountContext) -> ViewController {
+public func nagramSettingsController(context: AccountContext, deepLinkPath: String? = nil) -> ViewController {
     var currentShowCallsTab = CallListSettings.defaultSettings.showTab
     var currentContentSettingsConfiguration: ContentSettingsConfiguration?
     let contentSettingsConfigurationPromise = Promise<ContentSettingsConfiguration?>()
@@ -271,8 +539,12 @@ public func nagramSettingsController(context: AccountContext) -> ViewController 
         pushControllerImpl?(nagramMessageMenuSettingsController(context: context))
     })
     let flatRows: [NagramRow] = groups.flatMap { $0.rows }
+    let flatRowDeepLinks: [String] = groups.flatMap { group in
+        group.rows.map { nagramSettingsDeepLink(tab: group.tab, row: $0) }
+    }
+    let deepLinkTarget = nagramDeepLinkTarget(deepLinkPath: deepLinkPath, groups: groups)
 
-    let tabPromise = ValuePromise<Int32>(0, ignoreRepeated: true)
+    let tabPromise = ValuePromise<Int32>(deepLinkTarget.tab.rawValue, ignoreRepeated: true)
 
     // 本地刷新计数:toggle/choice 改值后 bump() 触发重建。slider 不 bump(节点自显示)。
     let updatePromise = ValuePromise<Int32>(0, ignoreRepeated: false)
@@ -321,6 +593,16 @@ public func nagramSettingsController(context: AccountContext) -> ViewController 
         if case let .slider(_, _, _, set) = flatRows[index] {
             set(value)
         }
+    }, copyDeepLink: { index in
+        guard flatRowDeepLinks.indices.contains(index) else {
+            return
+        }
+        let presentationData = context.sharedContext.currentPresentationData.with { $0 }
+        UIPasteboard.general.string = flatRowDeepLinks[index]
+        HapticFeedback().tap()
+        presentControllerImpl?(UndoOverlayController(presentationData: presentationData, content: .linkCopied(title: nil, text: presentationData.strings.Conversation_LinkCopied), elevatedLayout: false, animateInAsReplacement: false, action: { _ in
+            return false
+        }), nil)
     })
 
     let signal = combineLatest(queue: .mainQueue(),
@@ -342,6 +624,7 @@ public func nagramSettingsController(context: AccountContext) -> ViewController 
         // stableId 必须全局唯一且稳定:遍历所有 group 全局递增分配,当前 tab 只取子集。
         // 否则切 tab 时同 stableId 指向不同类型 entry,ItemList diff 会用错 item 类型 update node 而崩溃。
         var entries: [NagramSettingsEntry] = []
+        var initialScrollToItem: ListViewScrollToItem?
         var stableId: Int32 = 0
         var globalRowIndex = 0
         for (groupIndex, group) in groups.enumerated() {
@@ -360,6 +643,9 @@ public func nagramSettingsController(context: AccountContext) -> ViewController 
                 let rowIndex = globalRowIndex
                 globalRowIndex += 1
                 if isCurrent {
+                    if deepLinkTarget.rowIndex == rowIndex {
+                        initialScrollToItem = ListViewScrollToItem(index: entries.count, position: .visible, animated: false, curve: .Default(duration: nil), directionHint: .Down)
+                    }
                     switch row {
                     case let .toggle(titleKey, get, _):
                         entries.append(.toggle(stableId: rowStableId, section: sectionId, title: ngI18n(titleKey, lang), value: get(), enabled: true, enableInteractiveChanges: true, index: rowIndex))
@@ -384,7 +670,7 @@ public func nagramSettingsController(context: AccountContext) -> ViewController 
 
         let tabTitles = NagramTab.allCases.map { ngI18n($0.titleKey, lang) }
         let controllerState = ItemListControllerState(presentationData: ItemListPresentationData(presentationData), title: .sectionControl(tabTitles, Int(selectedTab)), leftNavigationButton: nil, rightNavigationButton: nil, backNavigationButton: ItemListBackButton(title: presentationData.strings.Common_Back))
-        let listState = ItemListNodeState(presentationData: ItemListPresentationData(presentationData), entries: entries, style: .blocks, animateChanges: false)
+        let listState = ItemListNodeState(presentationData: ItemListPresentationData(presentationData), entries: entries, style: .blocks, ensureVisibleItemTag: deepLinkTarget.rowIndex.map { NagramSettingsRowTag(index: $0) }, initialScrollToItem: initialScrollToItem, animateChanges: false)
 
         return (controllerState, (listState, arguments))
     }
@@ -394,6 +680,24 @@ public func nagramSettingsController(context: AccountContext) -> ViewController 
 
     let controller = ItemListController(context: context, state: signal)
     controller.navigationPresentation = .default
+    if let rowIndex = deepLinkTarget.rowIndex {
+        let targetTag = NagramSettingsRowTag(index: rowIndex)
+        controller.afterLayout { [weak controller] in
+            guard let controller else {
+                return
+            }
+            var didHighlight = false
+            for delay in [0.35, 0.75, 1.15] {
+                Queue.mainQueue().after(delay, { [weak controller] in
+                    guard !didHighlight, let itemNode = controller?.itemNode(forTag: targetTag) as? ItemListItemNode else {
+                        return
+                    }
+                    didHighlight = true
+                    itemNode.displayHighlight()
+                })
+            }
+        }
+    }
     controller.titleControlValueChanged = { index in
         tabPromise.set(Int32(index))
     }

--- a/Nagram/SettingsUI/Sources/NagramSliderItem.swift
+++ b/Nagram/SettingsUI/Sources/NagramSliderItem.swift
@@ -22,8 +22,10 @@ final class NagramSliderItem: ListViewItem, ItemListItem {
     let systemStyle: ItemListSystemStyle
     let sectionId: ItemListSectionId
     let updated: (Int32) -> Void
+    let longTapAction: (() -> Void)?
+    let tag: ItemListItemTag?
 
-    init(theme: PresentationTheme, minValue: Int32, maxValue: Int32, value: Int32, sectionId: ItemListSectionId, systemStyle: ItemListSystemStyle = .glass, updated: @escaping (Int32) -> Void) {
+    init(theme: PresentationTheme, minValue: Int32, maxValue: Int32, value: Int32, sectionId: ItemListSectionId, systemStyle: ItemListSystemStyle = .glass, updated: @escaping (Int32) -> Void, longTapAction: (() -> Void)? = nil, tag: ItemListItemTag? = nil) {
         self.theme = theme
         self.minValue = minValue
         self.maxValue = maxValue
@@ -31,6 +33,8 @@ final class NagramSliderItem: ListViewItem, ItemListItem {
         self.systemStyle = systemStyle
         self.sectionId = sectionId
         self.updated = updated
+        self.longTapAction = longTapAction
+        self.tag = tag
     }
 
     func nodeConfiguredForParams(async: @escaping (@escaping () -> Void) -> Void, params: ListViewItemLayoutParams, synchronousLoads: Bool, previousItem: ListViewItem?, nextItem: ListViewItem?, completion: @escaping (ListViewItemNode, @escaping () -> (Signal<Void, NoError>?, (ListViewItemApply) -> Void)) -> Void) {
@@ -62,8 +66,9 @@ final class NagramSliderItem: ListViewItem, ItemListItem {
     }
 }
 
-private final class NagramSliderItemNode: ListViewItemNode {
+private final class NagramSliderItemNode: ListViewItemNode, ItemListItemNode {
     private let backgroundNode: ASDisplayNode
+    private let highlightNode: ASDisplayNode
     private let topStripeNode: ASDisplayNode
     private let bottomStripeNode: ASDisplayNode
     private let maskNode: ASImageNode
@@ -77,9 +82,15 @@ private final class NagramSliderItemNode: ListViewItemNode {
     private var item: NagramSliderItem?
     private var layoutParams: ListViewItemLayoutParams?
 
+    var tag: ItemListItemTag? {
+        return self.item?.tag
+    }
+
     init() {
         self.backgroundNode = ASDisplayNode()
         self.backgroundNode.isLayerBacked = true
+        self.highlightNode = ASDisplayNode()
+        self.highlightNode.isLayerBacked = true
         self.topStripeNode = ASDisplayNode()
         self.topStripeNode.isLayerBacked = true
         self.bottomStripeNode = ASDisplayNode()
@@ -104,6 +115,36 @@ private final class NagramSliderItemNode: ListViewItemNode {
         return max(0.0, min(1.0, CGFloat(value - item.minValue) / span))
     }
 
+    override var canBeLongTapped: Bool {
+        return self.item?.longTapAction != nil
+    }
+
+    override func visibleForSelection(at point: CGPoint) -> Bool {
+        return point.y < 44.0
+    }
+
+    override func longTapped() {
+        self.item?.longTapAction?()
+    }
+
+    func displayHighlight() {
+        self.highlightNode.alpha = 1.0
+        if self.backgroundNode.supernode != nil {
+            self.insertSubnode(self.highlightNode, aboveSubnode: self.backgroundNode)
+        } else {
+            self.insertSubnode(self.highlightNode, at: 0)
+        }
+
+        Queue.mainQueue().after(1.2, { [weak self] in
+            guard let self else {
+                return
+            }
+            self.highlightNode.layer.animateAlpha(from: 1.0, to: 0.0, duration: 0.3, removeOnCompletion: false, completion: { [weak self] _ in
+                self?.highlightNode.removeFromSupernode()
+            })
+        })
+    }
+
     func asyncLayout() -> (_ item: NagramSliderItem, _ params: ListViewItemLayoutParams, _ neighbors: ItemListNeighbors) -> (ListViewItemNodeLayout, () -> Void) {
         return { item, params, neighbors in
             let separatorHeight = UIScreenPixel
@@ -125,6 +166,7 @@ private final class NagramSliderItemNode: ListViewItemNode {
                 strongSelf.layoutParams = params
 
                 strongSelf.backgroundNode.backgroundColor = item.theme.list.itemBlocksBackgroundColor
+                strongSelf.highlightNode.backgroundColor = item.theme.list.itemSearchHighlightColor
                 strongSelf.topStripeNode.backgroundColor = item.theme.list.itemBlocksSeparatorColor
                 strongSelf.bottomStripeNode.backgroundColor = item.theme.list.itemBlocksSeparatorColor
 
@@ -168,6 +210,7 @@ private final class NagramSliderItemNode: ListViewItemNode {
                 strongSelf.maskNode.image = hasCorners ? PresentationResourcesItemList.cornersImage(item.theme, top: hasTopCorners, bottom: hasBottomCorners, glass: item.systemStyle == .glass) : nil
 
                 strongSelf.backgroundNode.frame = CGRect(origin: CGPoint(x: 0.0, y: -min(insets.top, separatorHeight)), size: CGSize(width: params.width, height: contentSize.height + min(insets.top, separatorHeight) + min(insets.bottom, separatorHeight)))
+                strongSelf.highlightNode.frame = strongSelf.backgroundNode.frame
                 strongSelf.maskNode.frame = strongSelf.backgroundNode.frame.insetBy(dx: params.leftInset, dy: 0.0)
                 strongSelf.topStripeNode.frame = CGRect(origin: CGPoint(x: 0.0, y: -min(insets.top, separatorHeight)), size: CGSize(width: layoutSize.width, height: separatorHeight))
                 strongSelf.bottomStripeNode.frame = CGRect(origin: CGPoint(x: bottomStripeInset, y: contentSize.height + bottomStripeOffset), size: CGSize(width: layoutSize.width - bottomStripeInset - params.rightInset - separatorRightInset, height: separatorHeight))

--- a/submodules/ItemListUI/Sources/Items/ItemListDisclosureItem.swift
+++ b/submodules/ItemListUI/Sources/Items/ItemListDisclosureItem.swift
@@ -70,6 +70,8 @@ public class ItemListDisclosureItem: ListViewItem, ItemListItem, ListItemCompone
     let disclosureStyle: ItemListDisclosureStyle
     let noInsets: Bool
     let action: (() -> Void)?
+    // MARK: NAGRAM — Optional long-press action for copying setting deep links.
+    let longTapAction: (() -> Void)?
     let clearHighlightAutomatically: Bool
     public let tag: ItemListItemTag?
     public let shimmeringIndex: Int?
@@ -97,6 +99,7 @@ public class ItemListDisclosureItem: ListViewItem, ItemListItem, ListItemCompone
         disclosureStyle: ItemListDisclosureStyle = .arrow,
         noInsets: Bool = false,
         action: (() -> Void)?,
+        longTapAction: (() -> Void)? = nil,
         clearHighlightAutomatically: Bool = true,
         tag: ItemListItemTag? = nil,
         shimmeringIndex: Int? = nil
@@ -123,6 +126,7 @@ public class ItemListDisclosureItem: ListViewItem, ItemListItem, ListItemCompone
         self.disclosureStyle = disclosureStyle
         self.noInsets = noInsets
         self.action = action
+        self.longTapAction = longTapAction
         self.clearHighlightAutomatically = clearHighlightAutomatically
         self.tag = tag
         self.shimmeringIndex = shimmeringIndex
@@ -189,6 +193,10 @@ public class ItemListDisclosureItem: ListViewItem, ItemListItem, ListItemCompone
         if lhs.label != rhs.label {
             return false
         }
+        // MARK: NAGRAM — Long-press availability can change without title/label changes.
+        if (lhs.longTapAction == nil) != (rhs.longTapAction == nil) {
+            return false
+        }
         
         return true
     }
@@ -232,6 +240,15 @@ public class ItemListDisclosureItemNode: ListViewItemNode, ItemListItemNode {
     
     public var tag: ItemListItemTag? {
         return self.item?.tag
+    }
+
+    // MARK: NAGRAM — Long-press copies per-setting deep links when provided.
+    override public var canBeLongTapped: Bool {
+        return self.item?.longTapAction != nil
+    }
+
+    override public func longTapped() {
+        self.item?.longTapAction?()
     }
 
     private var placeholderNode: ShimmerEffectNode?

--- a/submodules/ItemListUI/Sources/Items/ItemListSwitchItem.swift
+++ b/submodules/ItemListUI/Sources/Items/ItemListSwitchItem.swift
@@ -42,9 +42,11 @@ public class ItemListSwitchItem: ListViewItem, ItemListItem {
     let updated: (Bool) -> Void
     let activatedWhileDisabled: () -> Void
     let action: (() -> Void)?
+    // MARK: NAGRAM — Optional long-press action for copying setting deep links.
+    let longTapAction: (() -> Void)?
     public let tag: ItemListItemTag?
     
-    public init(presentationData: ItemListPresentationData, systemStyle: ItemListSystemStyle = .legacy, icon: UIImage? = nil, title: String, text: String? = nil, textColor: TextColor = .primary, titleBadgeComponent: AnyComponent<Empty>? = nil, value: Bool, type: ItemListSwitchItemNodeType = .regular, enableInteractiveChanges: Bool = true, enabled: Bool = true, displayLocked: Bool = false, disableLeadingInset: Bool = false, maximumNumberOfLines: Int = 1, noCorners: Bool = false, editing: Bool = false, reorderable: Bool = false, sectionId: ItemListSectionId, style: ItemListStyle, updated: @escaping (Bool) -> Void, activatedWhileDisabled: @escaping () -> Void = {}, action: (() -> Void)? = nil, tag: ItemListItemTag? = nil) {
+    public init(presentationData: ItemListPresentationData, systemStyle: ItemListSystemStyle = .legacy, icon: UIImage? = nil, title: String, text: String? = nil, textColor: TextColor = .primary, titleBadgeComponent: AnyComponent<Empty>? = nil, value: Bool, type: ItemListSwitchItemNodeType = .regular, enableInteractiveChanges: Bool = true, enabled: Bool = true, displayLocked: Bool = false, disableLeadingInset: Bool = false, maximumNumberOfLines: Int = 1, noCorners: Bool = false, editing: Bool = false, reorderable: Bool = false, sectionId: ItemListSectionId, style: ItemListStyle, updated: @escaping (Bool) -> Void, activatedWhileDisabled: @escaping () -> Void = {}, action: (() -> Void)? = nil, longTapAction: (() -> Void)? = nil, tag: ItemListItemTag? = nil) {
         self.presentationData = presentationData
         self.systemStyle = systemStyle
         self.icon = icon
@@ -67,6 +69,7 @@ public class ItemListSwitchItem: ListViewItem, ItemListItem {
         self.updated = updated
         self.activatedWhileDisabled = activatedWhileDisabled
         self.action = action
+        self.longTapAction = longTapAction
         self.tag = tag
     }
     
@@ -740,6 +743,15 @@ public class ItemListSwitchItemNode: ListViewItemNode, ItemListItemNode {
     override public func animateRemoved(_ currentTimestamp: Double, duration: Double) {
         self.layer.allowsGroupOpacity = true
         self.layer.animateAlpha(from: 1.0, to: 0.0, duration: 0.15, removeOnCompletion: false)
+    }
+
+    // MARK: NAGRAM — Long-press copies per-setting deep links when provided.
+    override public var canBeLongTapped: Bool {
+        return self.item?.longTapAction != nil
+    }
+
+    override public func longTapped() {
+        self.item?.longTapAction?()
     }
     
     @objc private func switchValueChanged(_ switchView: UISwitch) {

--- a/submodules/TelegramUI/BUILD
+++ b/submodules/TelegramUI/BUILD
@@ -71,6 +71,7 @@ swift_library(
         "//Nagram/Settings:NagramSettings",
         "//Nagram/SettingsSignal:NagramSettingsSignal",
         "//Nagram/Strings:NagramStrings",
+        "//Nagram/SettingsUI:NagramSettingsUI",
         "//submodules/MediaPlayer:UniversalMediaPlayer",
         "//submodules/TelegramVoip:TelegramVoip",
         "//submodules/DeviceAccess:DeviceAccess",

--- a/submodules/TelegramUI/Sources/OpenResolvedUrl.swift
+++ b/submodules/TelegramUI/Sources/OpenResolvedUrl.swift
@@ -44,6 +44,7 @@ import ProxyServerPreviewScreen
 import AuthConfirmationScreen
 import OpenInExternalAppUI
 import CreateBotScreen
+import NagramSettingsUI // MARK: NAGRAM — open Nagram settings from nasettings deep links
 
 private func defaultNavigationForPeerId(_ peerId: PeerId?, navigation: ChatControllerInteractionNavigateToPeer) -> ChatControllerInteractionNavigateToPeer {
     if case .default = navigation {
@@ -59,6 +60,15 @@ private func defaultNavigationForPeerId(_ peerId: PeerId?, navigation: ChatContr
     } else {
         return navigation
     }
+}
+
+// MARK: NAGRAM — paths produced by t.me/nasettings and tg://nasettings.
+private func nagramSettingsDeepLinkPath(_ path: String) -> String? {
+    let normalized = path.lowercased()
+    if normalized == "nagram" || normalized.hasPrefix("nagram/") || normalized.hasPrefix("nagram?") {
+        return path
+    }
+    return nil
 }
 
 func openResolvedUrlImpl(
@@ -970,6 +980,10 @@ func openResolvedUrlImpl(
             switch section {
             case let .path(path):
                 if let navigationController {
+                    if let nagramPath = nagramSettingsDeepLinkPath(path) {
+                        navigationController.pushViewController(nagramSettingsController(context: context, deepLinkPath: nagramPath), animated: true)
+                        return
+                    }
                     if path.isEmpty {
                         if let rootController = context.sharedContext.mainWindow?.viewController as? TelegramRootController {
                             rootController.openSettings(edit: false)

--- a/submodules/TelegramUI/Sources/OpenUrl.swift
+++ b/submodules/TelegramUI/Sources/OpenUrl.swift
@@ -361,6 +361,16 @@ private func makeTelegramUrl(_ path: String, queryItems: [URLQueryItem] = []) ->
     return appendQueryItems(to: "https://t.me\(path)", items: queryItems)
 }
 
+// MARK: NAGRAM — keep tg://nasettings links compatible with https://t.me/nasettings links.
+private func makeNagramSettingsPath(pathComponents: [String], queryItems: [URLQueryItem]) -> String {
+    var result = "nagram"
+    let suffix = pathComponents.filter { $0 != "/" && !$0.isEmpty }
+    if !suffix.isEmpty {
+        result += "/" + suffix.joined(separator: "/")
+    }
+    return appendQueryItems(to: result, items: queryItems)
+}
+
 func openExternalUrlImpl(context: AccountContext, urlContext: OpenURLContext, url: String, forceExternal: Bool, presentationData: PresentationData, navigationController: NavigationController?, dismissInput: @escaping () -> Void) {
     if forceExternal || url.lowercased().hasPrefix("tel:") || url.lowercased().hasPrefix("calshow:") {
         if url.lowercased().hasPrefix("tel:+888") {
@@ -428,6 +438,20 @@ func openExternalUrlImpl(context: AccountContext, urlContext: OpenURLContext, ur
         if let scheme = parsedUrl.scheme, (scheme == "tg" || scheme == context.sharedContext.applicationBindings.appSpecificScheme) {
             var convertedUrl: String?
             let host = parsedUrl.host?.lowercased() ?? ""
+            // MARK: NAGRAM — support tg://nasettings[/section]?r=Key in addition to t.me/nasettings.
+            if host == "nasettings" {
+                let params = parsedUrl.query.flatMap(QueryParameters.init)
+                var pathComponents = parsedUrl.pathComponents.filter { $0 != "/" && !$0.isEmpty }
+                if pathComponents.isEmpty, let section = params?["section"] ?? params?["tab"], !section.isEmpty {
+                    pathComponents = [section]
+                }
+                let queryItems = (params?.items ?? []).filter { item in
+                    let name = item.name.lowercased()
+                    return name != "section" && name != "tab"
+                }
+                handleResolvedUrl(.settings(.path(makeNagramSettingsPath(pathComponents: pathComponents, queryItems: queryItems))))
+                return
+            }
             if let query = parsedUrl.query, let params = QueryParameters(query) {
                 switch host {
                 case "localpeer":

--- a/submodules/UrlHandling/Sources/UrlHandling.swift
+++ b/submodules/UrlHandling/Sources/UrlHandling.swift
@@ -153,12 +153,35 @@ public enum ParsedInternalUrl {
     case oauth(url: String)
     case createBot(parentBot: String, username: String?, title: String?)
     case textStyle(slug: String)
+    case settings(path: String) // MARK: NAGRAM — local Nagram settings deep link
     case externalUrl(url: String)
 }
 
 private enum ParsedUrl {
     case externalUrl(String)
     case internalUrl(ParsedInternalUrl)
+}
+
+// MARK: NAGRAM — preserve Android-compatible nasettings path/query through URL resolution.
+private func appendQueryItems(to base: String, items: [URLQueryItem]) -> String {
+    guard !items.isEmpty else {
+        return base
+    }
+    var components = URLComponents()
+    components.queryItems = items
+    guard let query = components.percentEncodedQuery, !query.isEmpty else {
+        return base
+    }
+    return "\(base)?\(query)"
+}
+
+private func nagramSettingsPath(pathComponents: [String], queryItems: [URLQueryItem]?) -> String {
+    var result = "nagram"
+    let suffix = pathComponents.dropFirst().filter { !$0.isEmpty }
+    if !suffix.isEmpty {
+        result += "/" + suffix.joined(separator: "/")
+    }
+    return appendQueryItems(to: result, items: queryItems ?? [])
 }
 
 public func parseInternalUrl(sharedContext: SharedAccountContext, context: AccountContext?, query: String) -> ParsedInternalUrl? {
@@ -179,6 +202,12 @@ public func parseInternalUrl(sharedContext: SharedAccountContext, context: Accou
         }
         if !pathComponents.isEmpty && !pathComponents[0].isEmpty {
             let peerName: String = pathComponents[0]
+            if peerName.lowercased() == "nasettings" {
+                guard pathComponents.count <= 2 else {
+                    return nil
+                }
+                return .settings(path: nagramSettingsPath(pathComponents: pathComponents, queryItems: components.queryItems))
+            }
             
             if query.hasPrefix("tonsite/") {
                 return .externalUrl(url: "tonsite://" + String(query[query.index(query.startIndex, offsetBy: "tonsite/".count)...]))
@@ -826,6 +855,8 @@ private enum ResolveInternalUrlResult {
 
 private func resolveInternalUrl(context: AccountContext, url: ParsedInternalUrl) -> Signal<ResolveInternalUrlResult, NoError> {
     switch url {
+        case let .settings(path):
+            return .single(.result(.settings(.path(path))))
         case let .phone(phone, attach, startAttach, text):
             return context.engine.peers.resolvePeerByPhone(phone: phone)
             |> mapToSignal { peer -> Signal<ResolveInternalUrlResult, NoError> in


### PR DESCRIPTION
## Summary
- Add `nasettings` deep links for opening Nagram settings and jumping to a specific row.
- Add long-press copy links for Nagram setting rows, including haptic feedback.
- Highlight the target setting row after opening a copied/deep-linked setting.

Closes #26

## Validation
- Full device build with extensions: `Build completed successfully`.
- Installed final build to `NextAlone’s iPhone` (`xyz.nextalone.nagram`).
