### PR TITLE
[codex] 隐藏设置页手机号

### DIFF
--- a/Nagram/Settings/NagramSettings.swift
+++ b/Nagram/Settings/NagramSettings.swift
@@ -176,6 +176,9 @@ public final class NagramSettings {
     /// 资料页显示注册日期（默认关 = 保持原生）
     @NagramDefault("nagram.showRegDate", false)
     public var showRegDate: Bool
+    /// 设置/资料页隐藏手机号（默认关 = 保持原生）
+    @NagramDefault("nagram.hidePhoneInSettings", false)
+    public var hidePhoneInSettings: Bool
 }
 
 public extension NagramSettings {

--- a/Nagram/SettingsUI/NagramSettingsController.swift
+++ b/Nagram/SettingsUI/NagramSettingsController.swift
@@ -161,6 +161,8 @@ private func nagramRowDeepLinkAliases(titleKey: String) -> [String] {
         return ["ShowDC", "ShowDataCenter", "ShowIdAndDc"]
     case "Nagram.ShowRegDate":
         return ["ShowRegDate", "RegistrationDate"]
+    case "Nagram.HidePhoneInSettings":
+        return ["HidePhone", "hidePhoneInSettings"]
     case "Nagram.ConfirmCalls":
         return ["AskBeforeCalling", "ConfirmCalls"]
     case "Nagram.DisableFiltering":
@@ -369,6 +371,7 @@ private func nagramGroups(
             .toggle(titleKey: "Nagram.ShowProfileId", get: { NagramSettings.shared.showProfileId }, set: { NagramSettings.shared.showProfileId = $0 }),
             .toggle(titleKey: "Nagram.ShowDC", get: { NagramSettings.shared.showDC }, set: { NagramSettings.shared.showDC = $0 }),
             .toggle(titleKey: "Nagram.ShowRegDate", get: { NagramSettings.shared.showRegDate }, set: { NagramSettings.shared.showRegDate = $0 }),
+            .toggle(titleKey: "Nagram.HidePhoneInSettings", get: { NagramSettings.shared.hidePhoneInSettings }, set: { NagramSettings.shared.hidePhoneInSettings = $0 }),
         ]),
         NagramGroup(tab: .other, headerKey: "Nagram.Section.Calls", footerKey: nil, rows: [
             .toggle(titleKey: "Nagram.ConfirmCalls", get: { NagramSettings.shared.confirmCalls }, set: { NagramSettings.shared.confirmCalls = $0 }),

--- a/Nagram/Strings/Strings/en.lproj/NagramLocalizable.strings
+++ b/Nagram/Strings/Strings/en.lproj/NagramLocalizable.strings
@@ -109,6 +109,7 @@
 "Nagram.ShowProfileId" = "Show User ID";
 "Nagram.ShowDC" = "Show Data Center";
 "Nagram.ShowRegDate" = "Show Registration Date";
+"Nagram.HidePhoneInSettings" = "Hide Phone Number in Settings";
 "Nagram.Section.Calls" = "Calls";
 "Nagram.ConfirmCalls" = "Confirm Before Calling";
 "Nagram.Section.Interface" = "Interface";

--- a/Nagram/Strings/Strings/ja.lproj/NagramLocalizable.strings
+++ b/Nagram/Strings/Strings/ja.lproj/NagramLocalizable.strings
@@ -109,6 +109,7 @@
 "Nagram.ShowProfileId" = "ユーザーIDを表示";
 "Nagram.ShowDC" = "データセンターを表示";
 "Nagram.ShowRegDate" = "登録日を表示";
+"Nagram.HidePhoneInSettings" = "設定の電話番号を非表示";
 "Nagram.Section.Calls" = "通話";
 "Nagram.ConfirmCalls" = "通話前に確認";
 "Nagram.Section.Interface" = "インターフェース";

--- a/Nagram/Strings/Strings/zh-hans.lproj/NagramLocalizable.strings
+++ b/Nagram/Strings/Strings/zh-hans.lproj/NagramLocalizable.strings
@@ -109,6 +109,7 @@
 "Nagram.ShowProfileId" = "显示用户 ID";
 "Nagram.ShowDC" = "显示数据中心";
 "Nagram.ShowRegDate" = "显示注册日期";
+"Nagram.HidePhoneInSettings" = "隐藏设置页手机号";
 "Nagram.Section.Calls" = "通话";
 "Nagram.ConfirmCalls" = "通话前确认";
 "Nagram.Section.Interface" = "界面";

--- a/Nagram/Strings/Strings/zh-hant.lproj/NagramLocalizable.strings
+++ b/Nagram/Strings/Strings/zh-hant.lproj/NagramLocalizable.strings
@@ -109,6 +109,7 @@
 "Nagram.ShowProfileId" = "顯示使用者 ID";
 "Nagram.ShowDC" = "顯示資料中心";
 "Nagram.ShowRegDate" = "顯示註冊日期";
+"Nagram.HidePhoneInSettings" = "隱藏設定頁手機號碼";
 "Nagram.Section.Calls" = "通話";
 "Nagram.ConfirmCalls" = "通話前確認";
 "Nagram.Section.Interface" = "介面";

--- a/submodules/TelegramUI/Components/PeerInfo/PeerInfoScreen/Sources/PeerInfoHeaderNode.swift
+++ b/submodules/TelegramUI/Components/PeerInfo/PeerInfoScreen/Sources/PeerInfoHeaderNode.swift
@@ -33,6 +33,8 @@ import PeerInfoVisualMediaPaneNode
 import AvatarStoryIndicatorComponent
 import ComponentDisplayAdapters
 import ChatAvatarNavigationNode
+// MARK: NAGRAM
+import NagramSettings
 import MultiScaleTextNode
 import PeerInfoCoverComponent
 import PeerInfoPaneNode
@@ -402,7 +404,8 @@ final class PeerInfoHeaderNode: ASDisplayNode {
     
     @objc private func handlePhoneLongPress(_ gestureRecognizer: UILongPressGestureRecognizer) {
         if gestureRecognizer.state == .began {
-            self.displayCopyContextMenu?(self.subtitleNodeRawContainer, true, !self.isAvatarExpanded)
+            // MARK: NAGRAM
+            self.displayCopyContextMenu?(self.subtitleNodeRawContainer, !NagramSettings.shared.hidePhoneInSettings, !self.isAvatarExpanded)
         }
     }
     
@@ -1235,10 +1238,12 @@ final class PeerInfoHeaderNode: ASDisplayNode {
             smallTitleAttributes = MultiScaleTextState.Attributes(font: Font.medium(28.0), color: .white, shadowColor: titleShadowColor)
             
             if self.isSettings, case let .user(user) = peer {
-                var subtitle = formatPhoneNumber(context: self.context, number: user.phone ?? "")
+                // MARK: NAGRAM
+                var subtitle = NagramSettings.shared.hidePhoneInSettings ? "" : formatPhoneNumber(context: self.context, number: user.phone ?? "")
                 
                 if let mainUsername = user.addressName, !mainUsername.isEmpty {
-                    subtitle = "\(subtitle) • @\(mainUsername)"
+                    // MARK: NAGRAM
+                    subtitle = subtitle.isEmpty ? "@\(mainUsername)" : "\(subtitle) • @\(mainUsername)"
                 }
                 subtitleStringText = subtitle
                 subtitleAttributes = MultiScaleTextState.Attributes(font: Font.regular(17.0), color: .white)

--- a/submodules/TelegramUI/Components/PeerInfo/PeerInfoScreen/Sources/PeerInfoProfileItems.swift
+++ b/submodules/TelegramUI/Components/PeerInfo/PeerInfoScreen/Sources/PeerInfoProfileItems.swift
@@ -140,7 +140,8 @@ func infoItems(
             }))
         }
         
-        if let phone = user.phone {
+        // MARK: NAGRAM
+        if let phone = user.phone, !NagramSettings.shared.hidePhoneInSettings {
             let formattedPhone = formatPhoneNumber(context: context, number: phone)
             let label: String
             if formattedPhone.hasPrefix("+888 ") {

--- a/submodules/TelegramUI/Components/PeerInfo/PeerInfoScreen/Sources/PeerInfoScreen.swift
+++ b/submodules/TelegramUI/Components/PeerInfo/PeerInfoScreen/Sources/PeerInfoScreen.swift
@@ -2162,6 +2162,10 @@ final class PeerInfoScreenNode: ViewControllerTracingNode, PeerInfoScreenNodePro
                         }
                     }))
                 }
+                // MARK: NAGRAM
+                if actions.isEmpty {
+                    return
+                }
                 
                 let contextMenuController = makeContextMenuController(actions: actions)
                 strongSelf.controller?.present(contextMenuController, in: .window(.root), with: ContextMenuControllerPresentationArguments(sourceNodeAndRect: { [weak self] in

--- a/submodules/TelegramUI/Components/PeerInfo/PeerInfoScreen/Sources/PeerInfoSettingsItems.swift
+++ b/submodules/TelegramUI/Components/PeerInfo/PeerInfoScreen/Sources/PeerInfoSettingsItems.swift
@@ -12,6 +12,8 @@ import ItemListPeerItem
 import DeviceAccess
 import TelegramStringFormatting
 import PeerNameColorItem
+// MARK: NAGRAM
+import NagramSettings
 
 // MARK: NAGRAM — nagram 为独立设置分组，排在「我的资料」之后
 enum SettingsSection: Int, CaseIterable {
@@ -453,7 +455,9 @@ func settingsEditingItems(data: PeerInfoScreenData?, state: PeerInfoState, conte
     }
     
     if case let .user(user) = data.peer {
-        items[.info]!.append(PeerInfoScreenDisclosureItem(id: ItemPhoneNumber, label: .text(user.phone.flatMap({ formatPhoneNumber(context: context, number: $0) }) ?? ""), text: presentationData.strings.Settings_PhoneNumber, icon: PresentationResourcesSettings.recentCalls, action: {
+        // MARK: NAGRAM
+        let phoneNumberLabel = NagramSettings.shared.hidePhoneInSettings ? "" : (user.phone.flatMap({ formatPhoneNumber(context: context, number: $0) }) ?? "")
+        items[.info]!.append(PeerInfoScreenDisclosureItem(id: ItemPhoneNumber, label: .text(phoneNumberLabel), text: presentationData.strings.Settings_PhoneNumber, icon: PresentationResourcesSettings.recentCalls, action: {
             interaction.openSettings(.phoneNumber)
         }))
     }


### PR DESCRIPTION
## Summary

Closes #29.

- Adds `NagramSettings.hidePhoneInSettings` with a Nagram settings toggle and localized strings.
- Hides the phone number text from the Settings header and phone-number row while keeping the phone-number settings entry usable.
- Skips the phone number item on profile info pages and prevents the hidden Settings header subtitle from exposing phone copy actions.

## Verification

- Full device build: `python3 build-system/Make/Make.py --overrideXcodeVersion --cacheDir ~/telegram-bazel-cache build --configurationPath build-input/local-configuration.json --codesigningInformationPath build-input/codesigning-development --buildNumber=1 --configuration=debug_arm64 --continueOnError`
- Result: `Build completed successfully, 617 total actions`; output `bazel-bin/Telegram/Telegram.ipa`.
