### PR TITLE
5 项新功能改进

### DIFF
--- a/Nagram/Settings/NagramMessageDoubleTapAction.swift
+++ b/Nagram/Settings/NagramMessageDoubleTapAction.swift
@@ -7,6 +7,7 @@ public enum NagramMessageDoubleTapAction: String {
     case reply
     case repeatMessage
     case repeatWithoutQuote
+    case translate
     case edit
 
     public static let allCases: [NagramMessageDoubleTapAction] = [
@@ -16,6 +17,7 @@ public enum NagramMessageDoubleTapAction: String {
         .reply,
         .repeatMessage,
         .repeatWithoutQuote,
+        .translate,
         .edit
     ]
 }

--- a/Nagram/Settings/NagramSettings.swift
+++ b/Nagram/Settings/NagramSettings.swift
@@ -180,6 +180,9 @@ public final class NagramSettings {
     /// 隐藏赞助消息和代理赞助频道入口
     @NagramDefault("nagram.hideSponsoredMessages", false)
     public var hideSponsoredMessages: Bool
+    /// 隐藏一对一私聊中对方的输入、上传和选贴纸状态
+    @NagramDefault("nagram.hidePrivateChatActivities", false)
+    public var hidePrivateChatActivities: Bool
     /// 通话前确认（默认关 = 保持原生无确认）
     @NagramDefault("nagram.confirmCalls", false)
     public var confirmCalls: Bool

--- a/Nagram/Settings/NagramSettings.swift
+++ b/Nagram/Settings/NagramSettings.swift
@@ -316,6 +316,9 @@ public final class NagramSettings {
     /// 首页分组标签紧凑布局
     @NagramDefault("nagram.chatListFolderTabsCompact", false)
     public var chatListFolderTabsCompact: Bool
+    /// 隐藏首页的“全部会话”分组（至少存在一个自定义分组时生效）
+    @NagramDefault("nagram.hideAllChatsFolder", false)
+    public var hideAllChatsFolder: Bool
     /// 首页分组标签显示方式（"text" / "icon" / "both"）
     @NagramDefault("nagram.chatListFolderTabDisplayMode", NagramChatListFolderTabDisplayMode.text.rawValue)
     public var chatListFolderTabDisplayMode: String

--- a/Nagram/Settings/NagramSettingsCloudSync.swift
+++ b/Nagram/Settings/NagramSettingsCloudSync.swift
@@ -15,6 +15,7 @@ enum NagramSettingsSyncKeys {
         "nagram.secondsInMessages",
         "nagram.hideChannelBottomButton",
         "nagram.hideSponsoredMessages",
+        "nagram.hidePrivateChatActivities",
         "nagram.confirmCalls",
         "nagram.showDC",
         "nagram.controlHighlightEnabled",

--- a/Nagram/Settings/NagramSettingsCloudSync.swift
+++ b/Nagram/Settings/NagramSettingsCloudSync.swift
@@ -29,6 +29,7 @@ enum NagramSettingsSyncKeys {
         "nagram.showArchiveInFolders",
         "nagram.chatListStartupFolderMode",
         "nagram.chatListFolderTabsCompact",
+        "nagram.hideAllChatsFolder",
         "nagram.chatListFolderTabDisplayMode",
         "nagram.chatListMessagePreviewStyle",
         "nagram.chatListLines",

--- a/Nagram/SettingsUI/NagramSettingsController.swift
+++ b/Nagram/SettingsUI/NagramSettingsController.swift
@@ -421,6 +421,7 @@ private func nagramGroups(
             .toggle(titleKey: "Nagram.HideReactions", get: { NagramSettings.shared.hideReactions }, set: { NagramSettings.shared.hideReactions = $0 }),
             .toggle(titleKey: "Nagram.HideChannelBottomButton", get: { NagramSettings.shared.hideChannelBottomButton }, set: { NagramSettings.shared.hideChannelBottomButton = $0 }),
             .toggle(titleKey: "Nagram.HideSponsoredMessages", get: { NagramSettings.shared.hideSponsoredMessages }, set: { NagramSettings.shared.hideSponsoredMessages = $0 }),
+            .toggle(titleKey: "Nagram.HidePrivateChatActivities", get: { NagramSettings.shared.hidePrivateChatActivities }, set: { NagramSettings.shared.hidePrivateChatActivities = $0 }),
         ]),
         NagramGroup(tab: .chat, headerKey: "Nagram.Section.Channels", footerKey: "Nagram.HideChannelForwardButton.Footer", rows: [
             .toggle(titleKey: "Nagram.HideChannelForwardButton", get: { NagramSettings.shared.wideChannelPosts }, set: { NagramSettings.shared.wideChannelPosts = $0 }),

--- a/Nagram/SettingsUI/NagramSettingsController.swift
+++ b/Nagram/SettingsUI/NagramSettingsController.swift
@@ -390,6 +390,7 @@ private func nagramGroups(
             .startupFolder(titleKey: "Nagram.ChatListStartupFolder"),
             .choice(titleKey: "Nagram.ChatListFolderTabDisplayMode", prefix: "Nagram.ChatListFolderTabDisplayMode", options: ["text", "icon", "both"], current: { NagramSettings.shared.chatListFolderTabDisplayModeValue.rawValue }, set: { NagramSettings.shared.chatListFolderTabDisplayMode = $0 }),
             .toggle(titleKey: "Nagram.ChatListFolderTabsCompact", get: { NagramSettings.shared.chatListFolderTabsCompact }, set: { NagramSettings.shared.chatListFolderTabsCompact = $0 }),
+            .toggle(titleKey: "Nagram.HideAllChatsFolder", get: { NagramSettings.shared.hideAllChatsFolder }, set: { NagramSettings.shared.hideAllChatsFolder = $0 }),
             .choice(titleKey: "Nagram.ChatListMessagePreviewStyle", prefix: "Nagram.ChatListMessagePreviewStyle", options: ["three", "two"], current: { NagramSettings.shared.chatListMessagePreviewStyleMode.rawValue }, set: { value in
                 if NagramSettings.shared.chatListCompact && value == NagramChatListMessagePreviewStyle.three.rawValue {
                     return

--- a/Nagram/Strings/Strings/en.lproj/NagramLocalizable.strings
+++ b/Nagram/Strings/Strings/en.lproj/NagramLocalizable.strings
@@ -70,6 +70,7 @@
 "Nagram.MessageDoubleTapAction.reply" = "Reply";
 "Nagram.MessageDoubleTapAction.repeatMessage" = "Repeat";
 "Nagram.MessageDoubleTapAction.repeatWithoutQuote" = "Repeat Without Quote";
+"Nagram.MessageDoubleTapAction.translate" = "Translate";
 "Nagram.MessageDoubleTapAction.edit" = "Edit";
 "Nagram.ChatListSwipeAction" = "Chat List Swipe";
 "Nagram.ChatListSwipeAction.both" = "Switch + Quick Actions";

--- a/Nagram/Strings/Strings/en.lproj/NagramLocalizable.strings
+++ b/Nagram/Strings/Strings/en.lproj/NagramLocalizable.strings
@@ -280,6 +280,7 @@
 "Nagram.ChatListFolderTabDisplayMode.icon" = "Icon Only";
 "Nagram.ChatListFolderTabDisplayMode.both" = "Icon and Text";
 "Nagram.ChatListFolderTabsCompact" = "Compact Folder Tabs";
+"Nagram.HideAllChatsFolder" = "Hide All Chats Folder";
 "Nagram.Section.Translation" = "Translation";
 "Nagram.Section.Translation.Footer" = "Only the translation provider is replaced; target language follows Telegram's native translate button. LLM supports OpenAI-compatible and Anthropic API formats; API Key is stored locally only. Other providers do not preserve formatting entities.";
 "Nagram.TranslationProvider" = "Translation Provider";

--- a/Nagram/Strings/Strings/en.lproj/NagramLocalizable.strings
+++ b/Nagram/Strings/Strings/en.lproj/NagramLocalizable.strings
@@ -16,6 +16,7 @@
 "Nagram.Section.Camera" = "Camera";
 "Nagram.Section.Camera.Footer" = "Camera entry and live preview in the attachment menu.";
 "Nagram.Section.MessageDisplay" = "Message Display";
+"Nagram.HidePrivateChatActivities" = "Hide Activity Status in Private Chats";
 "Nagram.TranslationProvider.llm" = "LLM";
 "Nagram.TranslationLLMSettings" = "LLM Settings";
 "Nagram.TranslationLLMSettings.Footer" = "Empty Base URL and Endpoint use the selected format defaults; Endpoint may also be a full URL. API Key is stored locally only.";

--- a/Nagram/Strings/Strings/ja.lproj/NagramLocalizable.strings
+++ b/Nagram/Strings/Strings/ja.lproj/NagramLocalizable.strings
@@ -16,6 +16,7 @@
 "Nagram.Section.Camera" = "カメラ";
 "Nagram.Section.Camera.Footer" = "添付メニュー内のカメラ入口とライブプレビュー。";
 "Nagram.Section.MessageDisplay" = "メッセージ表示";
+"Nagram.HidePrivateChatActivities" = "個人チャットのアクティビティを非表示";
 "Nagram.TranslationProvider.llm" = "LLM";
 "Nagram.TranslationLLMSettings" = "LLM 設定";
 "Nagram.TranslationLLMSettings.Footer" = "Base URL と Endpoint が空の場合、選択した形式の既定値を使います。Endpoint には完全な URL も入力できます。API Key は端末内にのみ保存されます。";

--- a/Nagram/Strings/Strings/ja.lproj/NagramLocalizable.strings
+++ b/Nagram/Strings/Strings/ja.lproj/NagramLocalizable.strings
@@ -70,6 +70,7 @@
 "Nagram.MessageDoubleTapAction.reply" = "返信";
 "Nagram.MessageDoubleTapAction.repeatMessage" = "リピート送信";
 "Nagram.MessageDoubleTapAction.repeatWithoutQuote" = "引用なしリピート送信";
+"Nagram.MessageDoubleTapAction.translate" = "翻訳";
 "Nagram.MessageDoubleTapAction.edit" = "編集";
 "Nagram.ChatListSwipeAction" = "チャットリスト横スワイプ";
 "Nagram.ChatListSwipeAction.both" = "切替 + クイック";

--- a/Nagram/Strings/Strings/ja.lproj/NagramLocalizable.strings
+++ b/Nagram/Strings/Strings/ja.lproj/NagramLocalizable.strings
@@ -280,6 +280,7 @@
 "Nagram.ChatListFolderTabDisplayMode.icon" = "アイコンのみ";
 "Nagram.ChatListFolderTabDisplayMode.both" = "アイコンとテキスト";
 "Nagram.ChatListFolderTabsCompact" = "フォルダタブをコンパクトに";
+"Nagram.HideAllChatsFolder" = "すべてのチャットを非表示";
 "Nagram.Section.Translation" = "翻訳";
 "Nagram.Section.Translation.Footer" = "翻訳 provider のみを置き換え、ターゲット言語は Telegram 標準の翻訳ボタンの選択に従います。LLM は OpenAI-compatible と Anthropic API 形式に対応し、API Key は端末内にのみ保存されます。他の provider は書式エンティティを保持しません。";
 "Nagram.TranslationProvider" = "翻訳 Provider";

--- a/Nagram/Strings/Strings/zh-hans.lproj/NagramLocalizable.strings
+++ b/Nagram/Strings/Strings/zh-hans.lproj/NagramLocalizable.strings
@@ -70,6 +70,7 @@
 "Nagram.MessageDoubleTapAction.reply" = "回复";
 "Nagram.MessageDoubleTapAction.repeatMessage" = "复读";
 "Nagram.MessageDoubleTapAction.repeatWithoutQuote" = "无引用复读";
+"Nagram.MessageDoubleTapAction.translate" = "翻译";
 "Nagram.MessageDoubleTapAction.edit" = "编辑";
 "Nagram.ChatListSwipeAction" = "对话列表横滑";
 "Nagram.ChatListSwipeAction.both" = "切换 + 快捷";

--- a/Nagram/Strings/Strings/zh-hans.lproj/NagramLocalizable.strings
+++ b/Nagram/Strings/Strings/zh-hans.lproj/NagramLocalizable.strings
@@ -280,6 +280,7 @@
 "Nagram.ChatListFolderTabDisplayMode.icon" = "仅图标";
 "Nagram.ChatListFolderTabDisplayMode.both" = "图标和文字";
 "Nagram.ChatListFolderTabsCompact" = "紧凑分组标签";
+"Nagram.HideAllChatsFolder" = "隐藏全部会话分组";
 "Nagram.Section.Translation" = "翻译";
 "Nagram.Section.Translation.Footer" = "只替换翻译 provider，目标语言跟随 Telegram 原生翻译按钮选择。LLM 支持 OpenAI-compatible 和 Anthropic API 格式；API Key 仅保存在本机。其他 provider 不保留富文本格式。";
 "Nagram.TranslationProvider" = "翻译 Provider";

--- a/Nagram/Strings/Strings/zh-hans.lproj/NagramLocalizable.strings
+++ b/Nagram/Strings/Strings/zh-hans.lproj/NagramLocalizable.strings
@@ -16,6 +16,7 @@
 "Nagram.Section.Camera" = "相机";
 "Nagram.Section.Camera.Footer" = "聊天附件面板中的相机入口与实时预览。";
 "Nagram.Section.MessageDisplay" = "消息显示";
+"Nagram.HidePrivateChatActivities" = "隐藏私聊活动状态";
 "Nagram.TranslationProvider.llm" = "LLM";
 "Nagram.TranslationLLMSettings" = "LLM 设置";
 "Nagram.TranslationLLMSettings.Footer" = "Base URL 和 Endpoint 为空时使用所选格式的默认地址；Endpoint 也可以填完整 URL。API Key 仅保存在本机。";

--- a/Nagram/Strings/Strings/zh-hant.lproj/NagramLocalizable.strings
+++ b/Nagram/Strings/Strings/zh-hant.lproj/NagramLocalizable.strings
@@ -16,6 +16,7 @@
 "Nagram.Section.Camera" = "相機";
 "Nagram.Section.Camera.Footer" = "聊天附件面板中的相機入口與即時預覽。";
 "Nagram.Section.MessageDisplay" = "訊息顯示";
+"Nagram.HidePrivateChatActivities" = "隱藏私聊活動狀態";
 "Nagram.TranslationProvider.llm" = "LLM";
 "Nagram.TranslationLLMSettings" = "LLM 設定";
 "Nagram.TranslationLLMSettings.Footer" = "Base URL 和 Endpoint 留空時使用所選格式的預設地址；Endpoint 也可以填完整 URL。API Key 僅保存在本機。";

--- a/Nagram/Strings/Strings/zh-hant.lproj/NagramLocalizable.strings
+++ b/Nagram/Strings/Strings/zh-hant.lproj/NagramLocalizable.strings
@@ -70,6 +70,7 @@
 "Nagram.MessageDoubleTapAction.reply" = "回覆";
 "Nagram.MessageDoubleTapAction.repeatMessage" = "復讀";
 "Nagram.MessageDoubleTapAction.repeatWithoutQuote" = "無引用復讀";
+"Nagram.MessageDoubleTapAction.translate" = "翻譯";
 "Nagram.MessageDoubleTapAction.edit" = "編輯";
 "Nagram.ChatListSwipeAction" = "對話列表橫滑";
 "Nagram.ChatListSwipeAction.both" = "切換 + 快捷";

--- a/Nagram/Strings/Strings/zh-hant.lproj/NagramLocalizable.strings
+++ b/Nagram/Strings/Strings/zh-hant.lproj/NagramLocalizable.strings
@@ -280,6 +280,7 @@
 "Nagram.ChatListFolderTabDisplayMode.icon" = "僅圖示";
 "Nagram.ChatListFolderTabDisplayMode.both" = "圖示和文字";
 "Nagram.ChatListFolderTabsCompact" = "緊湊分組標籤";
+"Nagram.HideAllChatsFolder" = "隱藏全部會話分組";
 "Nagram.Section.Translation" = "翻譯";
 "Nagram.Section.Translation.Footer" = "只替換翻譯 provider，目標語言跟隨 Telegram 原生翻譯按鈕選擇。LLM 支援 OpenAI-compatible 和 Anthropic API 格式；API Key 僅保存在本機。其他 provider 不保留富文字格式。";
 "Nagram.TranslationProvider" = "翻譯 Provider";

--- a/submodules/AccountUtils/Sources/AccountUtils.swift
+++ b/submodules/AccountUtils/Sources/AccountUtils.swift
@@ -4,8 +4,9 @@ import TelegramCore
 import TelegramUIPreferences
 import AccountContext
 
-public let maximumNumberOfAccounts = 3
-public let maximumPremiumNumberOfAccounts = 4
+// MARK: NAGRAM — Allow up to ten production accounts regardless of Premium status.
+public let maximumNumberOfAccounts = 10
+public let maximumPremiumNumberOfAccounts = 10
 
 public func activeAccountsAndPeers(context: AccountContext, includePrimary: Bool = false) -> Signal<((AccountContext, EnginePeer)?, [(AccountContext, EnginePeer, Int32)]), NoError> {
     let sharedContext = context.sharedContext

--- a/submodules/ChatListUI/Sources/ChatListController.swift
+++ b/submodules/ChatListUI/Sources/ChatListController.swift
@@ -804,10 +804,12 @@ public class ChatListControllerImpl: TelegramBaseController, ChatListController 
         self.nagramLayoutSettingsDisposable = (combineLatest(
             nagramBottomBarSettingsSignal(),
             nagramBoolSignal("nagram.chatListFolderTabsCompact", defaultValue: false),
-            nagramStringSignal("nagram.chatListFolderTabDisplayMode", defaultValue: NagramChatListFolderTabDisplayMode.text.rawValue)
+            nagramStringSignal("nagram.chatListFolderTabDisplayMode", defaultValue: NagramChatListFolderTabDisplayMode.text.rawValue),
+            nagramBoolSignal("nagram.hideAllChatsFolder", defaultValue: false)
         )
         |> deliverOnMainQueue).startStrict(next: { [weak self] _ in
             self?.requestLayout(transition: .animated(duration: 0.3, curve: .linear))
+            self?.reloadFilters()
         })
         
         self.globalControlPanelsContextStateDisposable = (self.globalControlPanelsContext.state
@@ -4011,11 +4013,21 @@ public class ChatListControllerImpl: TelegramBaseController, ChatListController 
             let (_, items) = countAndFilterItems
             var filterItems: [ChatListFilterTabEntry] = []
             var nagramFolderTabIcons: [ChatListFilterTabEntryId: String] = [:] // MARK: NAGRAM
+            // MARK: NAGRAM — Keep All Chats available when it is the only folder.
+            let hideAllChats = NagramSettings.shared.hideAllChatsFolder && items.contains(where: {
+                if case .filter = $0.0 {
+                    return true
+                }
+                return false
+            })
             
             for (filter, unreadCount, hasUnmutedUnread) in items {
                 switch filter {
                     case .allChats:
                         nagramFolderTabIcons[.all] = "💬" // MARK: NAGRAM
+                        if hideAllChats {
+                            continue
+                        }
                         if let isPremium = isPremium, !isPremium && filterItems.count > 0 {
                             filterItems.insert(.all(unreadCount: 0), at: 0)
                         } else {
@@ -4038,14 +4050,7 @@ public class ChatListControllerImpl: TelegramBaseController, ChatListController 
                 resolvedItems = []
             }
             
-            let firstItem = countAndFilterItems.1.first?.0 ?? .allChats
-            var firstItemEntryId: ChatListFilterTabEntryId // MARK: NAGRAM
-            switch firstItem {
-                case .allChats:
-                    firstItemEntryId = .all
-                case let .filter(id, _, _, _):
-                    firstItemEntryId = .filter(id)
-            }
+            var firstItemEntryId = resolvedItems.first?.id ?? .all // MARK: NAGRAM
             if !strongSelf.initializedFilters {
                 let accountPeerId = strongSelf.context.account.peerId.toInt64()
                 let configuredFolderId: Int32?
@@ -4069,7 +4074,8 @@ public class ChatListControllerImpl: TelegramBaseController, ChatListController 
                 if let tabContainerData = strongSelf.tabContainerData {
                     var found = false
                     if let index = tabContainerData.0.firstIndex(where: { $0.id == selectedEntryId }) {
-                        for i in (0 ..< index - 1).reversed() {
+                        // MARK: NAGRAM — Search preceding visible tabs without forming a negative range.
+                        for i in (0 ..< index).reversed() {
                             if resolvedItems.contains(where: { $0.id == tabContainerData.0[i].id }) {
                                 selectedEntryId = tabContainerData.0[i].id
                                 found = true
@@ -4078,10 +4084,10 @@ public class ChatListControllerImpl: TelegramBaseController, ChatListController 
                         }
                     }
                     if !found {
-                        selectedEntryId = .all
+                        selectedEntryId = resolvedItems.first?.id ?? .all // MARK: NAGRAM
                     }
                 } else {
-                    selectedEntryId = .all
+                    selectedEntryId = resolvedItems.first?.id ?? .all // MARK: NAGRAM
                 }
             }
             let filtersLimit = isPremium == false ? limits.maxFoldersCount : nil
@@ -4093,6 +4099,9 @@ public class ChatListControllerImpl: TelegramBaseController, ChatListController 
                 switch item.0 {
                     case .allChats:
                         hasAllChats = true
+                        if hideAllChats {
+                            continue
+                        }
                         if let isPremium = isPremium, !isPremium && availableFilters.count > 0 {
                             availableFilters.insert(.all, at: 0)
                         } else {
@@ -4102,7 +4111,7 @@ public class ChatListControllerImpl: TelegramBaseController, ChatListController 
                         availableFilters.append(.filter(item.0))
                 }
             }
-            if !hasAllChats {
+            if !hasAllChats && !hideAllChats {
                 availableFilters.insert(.all, at: 0)
             }
             strongSelf.chatListDisplayNode.mainContainerNode.updateAvailableFilters(availableFilters, limit: filtersLimit)

--- a/submodules/ChatListUI/Sources/ChatListController.swift
+++ b/submodules/ChatListUI/Sources/ChatListController.swift
@@ -95,6 +95,9 @@ private final class ContextControllerContentSourceImpl: ContextControllerContent
 }
 
 public class ChatListControllerImpl: TelegramBaseController, ChatListController {
+    // MARK: NAGRAM
+    public var settingsContextAction: ((UIView, ContextGesture) -> Void)?
+
     private var validLayout: ContainerViewLayout?
     
     public let context: AccountContext
@@ -7389,6 +7392,12 @@ private final class ChatListLocationContext {
                         content: .more,
                         pressed: { [weak self] _ in
                             self?.parentController?.settingsPressed()
+                        },
+                        contextAction: { [weak self] sourceView, gesture in
+                            guard let self, let gesture else {
+                                return
+                            }
+                            self.parentController?.settingsContextAction?(sourceView, gesture)
                         }
                     )))
                 } else {

--- a/submodules/ChatListUI/Sources/ChatListControllerNode.swift
+++ b/submodules/ChatListUI/Sources/ChatListControllerNode.swift
@@ -905,9 +905,13 @@ public final class ChatListContainerNode: ASDisplayNode, ASGestureRecognizerDele
                 }
             }
             if !availableFilters.contains(where: { $0.id == self.selectedId }) {
-                self.switchToFilter(id: .all, completion: {
+                // MARK: NAGRAM — Fall back to a filter that remains visible when All Chats is hidden.
+                if let fallbackId = availableFilters.first?.id {
                     apply()
-                })
+                    self.switchToFilter(id: fallbackId, animated: false)
+                } else {
+                    apply()
+                }
             } else {
                 apply()
             }

--- a/submodules/ChatListUI/Sources/Node/ChatListNode.swift
+++ b/submodules/ChatListUI/Sources/Node/ChatListNode.swift
@@ -2765,10 +2765,18 @@ public final class ChatListNode: ListViewImpl {
         let engine = context.engine
         let previousPeerCache = Atomic<[EnginePeer.Id: EnginePeer]>(value: [:])
         let previousActivities = Atomic<ChatListNodePeerInputActivities?>(value: nil)
-        self.activityStatusesDisposable = (context.account.allPeerInputActivities()
-        |> mapToSignal { activitiesByPeerId -> Signal<[ChatListNodePeerInputActivities.ItemId: [(EnginePeer, PeerInputActivity)]], NoError> in
+        // MARK: NAGRAM — 私聊 activity 隐藏设置需即时刷新聊天列表状态。
+        self.activityStatusesDisposable = (combineLatest(
+            context.account.allPeerInputActivities(),
+            nagramBoolSignal("nagram.hidePrivateChatActivities", defaultValue: false)
+        )
+        |> mapToSignal { activitiesByPeerId, hidePrivateChatActivities -> Signal<[ChatListNodePeerInputActivities.ItemId: [(EnginePeer, PeerInputActivity)]], NoError> in
             var activitiesByPeerId = activitiesByPeerId
             for key in activitiesByPeerId.keys {
+                if hidePrivateChatActivities && (key.peerId.namespace == Namespaces.Peer.CloudUser || key.peerId.namespace == Namespaces.Peer.SecretChat) {
+                    activitiesByPeerId[key] = nil
+                    continue
+                }
                 activitiesByPeerId[key]?.removeAll(where: { _, activity in
                     switch activity {
                     case .interactingWithEmoji:

--- a/submodules/SettingsUI/Sources/DeleteAccountOptionsController.swift
+++ b/submodules/SettingsUI/Sources/DeleteAccountOptionsController.swift
@@ -201,31 +201,27 @@ public func deleteAccountOptionsController(context: AccountContext, navigationCo
         |> take(1)
         |> deliverOnMainQueue
         ).start(next: { accountAndPeer, accountsAndPeers in
-            var maximumAvailableAccounts: Int = 3
+            // MARK: NAGRAM
+            var maximumAvailableAccounts = maximumNumberOfAccounts
             if accountAndPeer?.1.isPremium == true && !context.account.testingEnvironment {
-                maximumAvailableAccounts = 4
+                maximumAvailableAccounts = maximumPremiumNumberOfAccounts
             }
             var count: Int = 1
             for (accountContext, peer, _) in accountsAndPeers {
                 if !accountContext.account.testingEnvironment {
                     if peer.isPremium {
-                        maximumAvailableAccounts = 4
+                        maximumAvailableAccounts = maximumPremiumNumberOfAccounts
                     }
                     count += 1
                 }
             }
 
             if count >= maximumAvailableAccounts {
-                var replaceImpl: ((ViewController) -> Void)?
-                let controller = PremiumLimitScreen(context: context, subject: .accounts, count: Int32(count), action: {
-                    let controller = PremiumIntroScreen(context: context, source: .accounts)
-                    replaceImpl?(controller)
-                    return true
-                })
-                replaceImpl = { [weak controller] c in
-                    controller?.replace(with: c)
-                }
-                pushControllerImpl?(controller)
+                // MARK: NAGRAM — Both account limits are 10, so Premium cannot raise this limit.
+                let presentationData = context.sharedContext.currentPresentationData.with { $0 }
+                presentControllerImpl?(textAlertController(context: context, title: nil, text: presentationData.strings.Premium_MaxAccountsFinalText("\(maximumAvailableAccounts)").string, actions: [
+                    TextAlertAction(type: .defaultAction, title: presentationData.strings.Common_OK, action: {})
+                ], parseMarkdown: true), nil)
             } else {
                 context.sharedContext.beginNewAuth(testingEnvironment: context.account.testingEnvironment)
 
@@ -468,4 +464,3 @@ public func deleteAccountOptionsController(context: AccountContext, navigationCo
 
     return controller
 }
-

--- a/submodules/SettingsUI/Sources/LogoutOptionsController.swift
+++ b/submodules/SettingsUI/Sources/LogoutOptionsController.swift
@@ -139,31 +139,27 @@ public func logoutOptionsController(context: AccountContext, navigationControlle
         |> take(1)
         |> deliverOnMainQueue
         ).start(next: { accountAndPeer, accountsAndPeers in
-            var maximumAvailableAccounts: Int = 3
+            // MARK: NAGRAM
+            var maximumAvailableAccounts = maximumNumberOfAccounts
             if accountAndPeer?.1.isPremium == true && !context.account.testingEnvironment {
-                maximumAvailableAccounts = 4
+                maximumAvailableAccounts = maximumPremiumNumberOfAccounts
             }
             var count: Int = 1
             for (accountContext, peer, _) in accountsAndPeers {
                 if !accountContext.account.testingEnvironment {
                     if peer.isPremium {
-                        maximumAvailableAccounts = 4
+                        maximumAvailableAccounts = maximumPremiumNumberOfAccounts
                     }
                     count += 1
                 }
             }
             
             if count >= maximumAvailableAccounts {
-                var replaceImpl: ((ViewController) -> Void)?
-                let controller = PremiumLimitScreen(context: context, subject: .accounts, count: Int32(count), action: {
-                    let controller = PremiumIntroScreen(context: context, source: .accounts)
-                    replaceImpl?(controller)
-                    return true
-                })
-                replaceImpl = { [weak controller] c in
-                    controller?.replace(with: c)
-                }
-                pushControllerImpl?(controller)
+                // MARK: NAGRAM — Both account limits are 10, so Premium cannot raise this limit.
+                let presentationData = context.sharedContext.currentPresentationData.with { $0 }
+                presentControllerImpl?(textAlertController(context: context, title: nil, text: presentationData.strings.Premium_MaxAccountsFinalText("\(maximumAvailableAccounts)").string, actions: [
+                    TextAlertAction(type: .defaultAction, title: presentationData.strings.Common_OK, action: {})
+                ], parseMarkdown: true), nil)
             } else {
                 context.sharedContext.beginNewAuth(testingEnvironment: context.account.testingEnvironment)
                 
@@ -303,4 +299,3 @@ public func logoutOptionsController(context: AccountContext, navigationControlle
     
     return controller
 }
-

--- a/submodules/TelegramUI/Components/Chat/ChatMessageAnimatedStickerItemNode/Sources/ChatMessageAnimatedStickerItemNode.swift
+++ b/submodules/TelegramUI/Components/Chat/ChatMessageAnimatedStickerItemNode/Sources/ChatMessageAnimatedStickerItemNode.swift
@@ -2130,7 +2130,7 @@ public class ChatMessageAnimatedStickerItemNode: ChatMessageItemView {
                 item.controllerInteraction.setupReply(message.id)
             }
             return true
-        case .repeatMessage, .repeatWithoutQuote, .edit:
+        case .repeatMessage, .repeatWithoutQuote, .translate, .edit:
             let _ = item.controllerInteraction.nagramPerformMessageDoubleTapAction(message, action.rawValue)
             return true
         }

--- a/submodules/TelegramUI/Components/Chat/ChatMessageBubbleItemNode/Sources/ChatMessageBubbleItemNode.swift
+++ b/submodules/TelegramUI/Components/Chat/ChatMessageBubbleItemNode/Sources/ChatMessageBubbleItemNode.swift
@@ -5596,7 +5596,7 @@ public class ChatMessageBubbleItemNode: ChatMessageItemView, ChatMessagePreviewI
                 item.controllerInteraction.setupReply(message.id)
             }
             return true
-        case .repeatMessage, .repeatWithoutQuote, .edit:
+        case .repeatMessage, .repeatWithoutQuote, .translate, .edit:
             let _ = item.controllerInteraction.nagramPerformMessageDoubleTapAction(message, action.rawValue)
             return true
         }

--- a/submodules/TelegramUI/Components/Chat/ChatMessageInstantVideoItemNode/Sources/ChatMessageInstantVideoItemNode.swift
+++ b/submodules/TelegramUI/Components/Chat/ChatMessageInstantVideoItemNode/Sources/ChatMessageInstantVideoItemNode.swift
@@ -1009,7 +1009,7 @@ public class ChatMessageInstantVideoItemNode: ChatMessageItemView, ASGestureReco
                 item.controllerInteraction.setupReply(message.id)
             }
             return true
-        case .repeatMessage, .repeatWithoutQuote, .edit:
+        case .repeatMessage, .repeatWithoutQuote, .translate, .edit:
             let _ = item.controllerInteraction.nagramPerformMessageDoubleTapAction(message, action.rawValue)
             return true
         }

--- a/submodules/TelegramUI/Components/Chat/ChatMessageStickerItemNode/Sources/ChatMessageStickerItemNode.swift
+++ b/submodules/TelegramUI/Components/Chat/ChatMessageStickerItemNode/Sources/ChatMessageStickerItemNode.swift
@@ -1567,7 +1567,7 @@ public class ChatMessageStickerItemNode: ChatMessageItemView {
                 item.controllerInteraction.setupReply(message.id)
             }
             return true
-        case .repeatMessage, .repeatWithoutQuote, .edit:
+        case .repeatMessage, .repeatWithoutQuote, .translate, .edit:
             let _ = item.controllerInteraction.nagramPerformMessageDoubleTapAction(message, action.rawValue)
             return true
         }

--- a/submodules/TelegramUI/Components/PeerInfo/PeerInfoScreen/Sources/PeerInfoScreen.swift
+++ b/submodules/TelegramUI/Components/PeerInfo/PeerInfoScreen/Sources/PeerInfoScreen.swift
@@ -7251,6 +7251,15 @@ public final class PeerInfoScreenImpl: ViewController, PeerInfoScreen, KeyShortc
     }
     
     override public func tabBarItemContextAction(sourceView: ContextExtractedContentContainingView, gesture: ContextGesture) {
+        self.presentAccountSwitcher(source: .reference(SettingsTabBarContextReferenceContentSource(controller: self, sourceView: sourceView)), gesture: gesture)
+    }
+
+    // MARK: NAGRAM — expose the existing account switcher for the chat-list header settings button.
+    public func presentAccountSwitcher(sourceView: UIView, gesture: ContextGesture, addAccount: (() -> Void)? = nil) {
+        self.presentAccountSwitcher(source: .reference(SettingsHeaderContextReferenceContentSource(controller: self, sourceView: sourceView)), gesture: gesture, addAccount: addAccount)
+    }
+
+    private func presentAccountSwitcher(source: ContextContentSource, gesture: ContextGesture, addAccount: (() -> Void)? = nil) {
         guard let (maybePrimary, other) = self.accountsAndPeersValue, let primary = maybePrimary else {
             return
         }
@@ -7258,15 +7267,25 @@ public final class PeerInfoScreenImpl: ViewController, PeerInfoScreen, KeyShortc
         let strings = self.presentationData.strings
         
         var items: [ContextMenuItem] = []
-        items.append(.action(ContextMenuActionItem(text: strings.Settings_AddAccount, icon: { theme in
-            return generateTintedImage(image: UIImage(bundleImageName: "Chat/Context Menu/Add"), color: theme.contextMenu.primaryColor)
-        }, action: { [weak self] _, f in
-            guard let strongSelf = self else {
-                return
-            }
-            strongSelf.controllerNode.openSettings(section: .addAccount)
-            f(.dismissWithoutContent)
-        })))
+        // MARK: NAGRAM — The hidden Settings tab has no navigation controller, so start auth directly.
+        let productionAccountCount = other.reduce(1, { count, account in
+            return account.0.account.testingEnvironment ? count : count + 1
+        })
+        if addAccount == nil || productionAccountCount < maximumNumberOfAccounts {
+            items.append(.action(ContextMenuActionItem(text: strings.Settings_AddAccount, icon: { theme in
+                return generateTintedImage(image: UIImage(bundleImageName: "Chat/Context Menu/Add"), color: theme.contextMenu.primaryColor)
+            }, action: { [weak self] _, f in
+                guard let strongSelf = self else {
+                    return
+                }
+                if let addAccount {
+                    addAccount()
+                } else {
+                    strongSelf.controllerNode.openSettings(section: .addAccount)
+                }
+                f(.dismissWithoutContent)
+            })))
+        }
         
         
         //let avatarSize = CGSize(width: 28.0, height: 28.0)
@@ -7301,7 +7320,7 @@ public final class PeerInfoScreenImpl: ViewController, PeerInfoScreen, KeyShortc
             })))*/
         }
         
-        let controller = makeContextController(presentationData: self.presentationData, source: .reference(SettingsTabBarContextReferenceContentSource(controller: self, sourceView: sourceView)), items: .single(ContextController.Items(content: .list(items))), recognizer: nil, gesture: gesture)
+        let controller = makeContextController(presentationData: self.presentationData, source: source, items: .single(ContextController.Items(content: .list(items))), recognizer: nil, gesture: gesture)
         self.context.sharedContext.mainWindow?.presentInGlobalOverlay(controller)
     }
     
@@ -7458,6 +7477,27 @@ final class SettingsTabBarContextReferenceContentSource: ContextReferenceContent
             referenceView: self.sourceView.contentView,
             contentAreaInScreenSpace: UIScreen.main.bounds,
             actionsPosition: .top
+        )
+    }
+}
+
+// MARK: NAGRAM
+final class SettingsHeaderContextReferenceContentSource: ContextReferenceContentSource {
+    let keepInPlace: Bool = true
+
+    private let controller: ViewController
+    private let sourceView: UIView
+
+    init(controller: ViewController, sourceView: UIView) {
+        self.controller = controller
+        self.sourceView = sourceView
+    }
+
+    func transitionInfo() -> ContextControllerReferenceViewInfo? {
+        return ContextControllerReferenceViewInfo(
+            referenceView: self.sourceView,
+            contentAreaInScreenSpace: UIScreen.main.bounds,
+            actionsPosition: .bottom
         )
     }
 }

--- a/submodules/TelegramUI/Components/PeerInfo/PeerInfoScreen/Sources/PeerInfoScreenSettingsActions.swift
+++ b/submodules/TelegramUI/Components/PeerInfo/PeerInfoScreen/Sources/PeerInfoScreenSettingsActions.swift
@@ -231,33 +231,26 @@ extension PeerInfoScreenNode {
                 guard let strongSelf = self else {
                     return
                 }
-                var maximumAvailableAccounts: Int = 3
+                // MARK: NAGRAM
+                var maximumAvailableAccounts = maximumNumberOfAccounts
                 if accountAndPeer?.1.isPremium == true && !strongSelf.context.account.testingEnvironment {
-                    maximumAvailableAccounts = 4
+                    maximumAvailableAccounts = maximumPremiumNumberOfAccounts
                 }
                 var count: Int = 1
                 for (accountContext, peer, _) in accountsAndPeers {
                     if !accountContext.account.testingEnvironment {
                         if peer.isPremium {
-                            maximumAvailableAccounts = 4
+                            maximumAvailableAccounts = maximumPremiumNumberOfAccounts
                         }
                         count += 1
                     }
                 }
                 
                 if count >= maximumAvailableAccounts {
-                    var replaceImpl: ((ViewController) -> Void)?
-                    let controller = PremiumLimitScreen(context: strongSelf.context, subject: .accounts, count: Int32(count), action: {
-                        let controller = PremiumIntroScreen(context: strongSelf.context, source: .accounts)
-                        replaceImpl?(controller)
-                        return true
-                    })
-                    replaceImpl = { [weak controller] c in
-                        controller?.replace(with: c)
-                    }
-                    if let navigationController = strongSelf.context.sharedContext.mainWindow?.viewController as? NavigationController {
-                        navigationController.pushViewController(controller)
-                    }
+                    // MARK: NAGRAM — Both account limits are 10, so Premium cannot raise this limit.
+                    strongSelf.controller?.present(textAlertController(context: strongSelf.context, updatedPresentationData: strongSelf.controller?.updatedPresentationData, title: nil, text: strongSelf.presentationData.strings.Premium_MaxAccountsFinalText("\(maximumAvailableAccounts)").string, actions: [
+                        TextAlertAction(type: .defaultAction, title: strongSelf.presentationData.strings.Common_OK, action: {})
+                    ], parseMarkdown: true), in: .window(.root))
                 } else {
                     strongSelf.context.sharedContext.beginNewAuth(testingEnvironment: strongSelf.context.account.testingEnvironment)
                 }

--- a/submodules/TelegramUI/Sources/Chat/ChatControllerLoadDisplayNode.swift
+++ b/submodules/TelegramUI/Sources/Chat/ChatControllerLoadDisplayNode.swift
@@ -80,6 +80,7 @@ import StickerPackPreviewUI
 import TextNodeWithEntities
 // MARK: NAGRAM
 import NagramSettings
+import NagramSettingsSignal
 import EntityKeyboard
 import ChatTitleView
 import EmojiStatusComponent
@@ -5107,8 +5108,9 @@ extension ChatControllerImpl {
                 
                 if let activitySpace = activitySpace, let peerId = peerId {
                     self.peerInputActivitiesDisposable?.dispose()
-                    self.peerInputActivitiesDisposable = (self.context.account.peerInputActivities(peerId: activitySpace)
-                    |> mapToSignal { activities -> Signal<[(EnginePeer, PeerInputActivity)], NoError> in
+                    self.peerInputActivitiesDisposable = (combineLatest(
+                        self.context.account.peerInputActivities(peerId: activitySpace)
+                        |> mapToSignal { activities -> Signal<[(EnginePeer, PeerInputActivity)], NoError> in
                         var foundAllPeers = true
                         var cachedResult: [(EnginePeer, PeerInputActivity)] = []
                         previousPeerCache.with { dict -> Void in
@@ -5140,10 +5142,15 @@ extension ChatControllerImpl {
                                 return result
                             }
                         }
-                    }
-                    |> deliverOnMainQueue).startStrict(next: { [weak self] activities in
+                        },
+                        // MARK: NAGRAM — 私聊 activity 隐藏设置需即时刷新标题状态。
+                        nagramBoolSignal("nagram.hidePrivateChatActivities", defaultValue: false)
+                    )
+                    |> deliverOnMainQueue).startStrict(next: { [weak self] activities, hidePrivateChatActivities in
                         if let strongSelf = self {
-                            let displayActivities = activities.filter({
+                            let isPrivateChat = peerId.namespace == Namespaces.Peer.CloudUser || peerId.namespace == Namespaces.Peer.SecretChat
+                            let visibleActivities = hidePrivateChatActivities && isPrivateChat ? [] : activities
+                            let displayActivities = visibleActivities.filter({
                                 switch $0.1 {
                                     case .speakingInGroupCall, .interactingWithEmoji:
                                         return false

--- a/submodules/TelegramUI/Sources/ChatController.swift
+++ b/submodules/TelegramUI/Sources/ChatController.swift
@@ -11139,6 +11139,18 @@ public final class ChatControllerImpl: TelegramBaseController, ChatController, G
                 hideNames = false
             }
             return self.nagramRepeatMessages(messages: [message], hideNames: hideNames)
+        case .translate:
+            guard !message.text.isEmpty, message.id.peerId.namespace != Namespaces.Peer.SecretChat else {
+                return true
+            }
+            self.controllerInteraction?.performTextSelectionAction(
+                message,
+                !message.isCopyProtected(),
+                NSAttributedString(string: message.text),
+                message.textEntitiesAttribute?.entities,
+                .translate
+            )
+            return true
         case .edit:
             guard self.nagramCanEditMessage(message) else {
                 return false

--- a/submodules/TelegramUI/Sources/TelegramRootController.swift
+++ b/submodules/TelegramUI/Sources/TelegramRootController.swift
@@ -291,6 +291,15 @@ public final class TelegramRootController: NavigationController, TelegramRootCon
         }
         
         let accountSettingsController = PeerInfoScreenImpl(context: self.context, updatedPresentationData: nil, peerId: self.context.account.peerId, avatarInitiallyExpanded: false, isOpenedFromChat: false, reactionSourceMessageId: nil, callMessages: [], isSettings: true)
+        // MARK: NAGRAM — reuse the settings tab account switcher from the hidden-tab-bar header button.
+        (chatListController as? ChatListControllerImpl)?.settingsContextAction = { [weak self, weak accountSettingsController] sourceView, gesture in
+            accountSettingsController?.presentAccountSwitcher(sourceView: sourceView, gesture: gesture, addAccount: { [weak self] in
+                guard let self else {
+                    return
+                }
+                self.context.sharedContext.beginNewAuth(testingEnvironment: self.context.account.testingEnvironment)
+            })
+        }
         accountSettingsController.tabBarItemDebugTapAction = { [weak self] in
             guard let strongSelf = self else {
                 return


### PR DESCRIPTION
- 双击翻译消息
- 可登录更多账号（目前是 10 个）
- 隐藏 All chats 文件夹
- 关闭底栏时，长按设置按钮切换账户
- 私聊时关闭输入状态显示