### PR TITLE
fix: preserve folder fallback during filter updates

### DIFF
--- a/submodules/ChatListUI/Sources/ChatListController.swift
+++ b/submodules/ChatListUI/Sources/ChatListController.swift
@@ -4068,9 +4068,7 @@ public class ChatListControllerImpl: TelegramBaseController, ChatListController 
             }
             
             var selectedEntryId = !strongSelf.initializedFilters ? firstItemEntryId : strongSelf.chatListDisplayNode.mainContainerNode.currentItemFilter
-            var resetCurrentEntry = false
             if !resolvedItems.contains(where: { $0.id == selectedEntryId }) {
-                resetCurrentEntry = true
                 if let tabContainerData = strongSelf.tabContainerData {
                     var found = false
                     if let index = tabContainerData.0.firstIndex(where: { $0.id == selectedEntryId }) {
@@ -4114,7 +4112,7 @@ public class ChatListControllerImpl: TelegramBaseController, ChatListController 
             if !hasAllChats && !hideAllChats {
                 availableFilters.insert(.all, at: 0)
             }
-            strongSelf.chatListDisplayNode.mainContainerNode.updateAvailableFilters(availableFilters, limit: filtersLimit)
+            strongSelf.chatListDisplayNode.mainContainerNode.updateAvailableFilters(availableFilters, limit: filtersLimit, fallbackId: selectedEntryId)
             
             if isPremium == nil && items.isEmpty {
                 strongSelf.mainReady.set(strongSelf.chatListDisplayNode.mainContainerNode.currentItemNode.ready)
@@ -4143,10 +4141,6 @@ public class ChatListControllerImpl: TelegramBaseController, ChatListController 
             if !notifiedFirstUpdate {
                 notifiedFirstUpdate = true
                 firstUpdate?()
-            }
-            
-            if resetCurrentEntry {
-                strongSelf.selectTab(id: selectedEntryId, switchToChatsIfNeeded: false)
             }
         }))
     }

--- a/submodules/ChatListUI/Sources/ChatListControllerNode.swift
+++ b/submodules/ChatListUI/Sources/ChatListControllerNode.swift
@@ -892,7 +892,7 @@ public final class ChatListContainerNode: ASDisplayNode, ASGestureRecognizerDele
         }
     }
     
-    public func updateAvailableFilters(_ availableFilters: [ChatListContainerNodeFilter], limit: Int32?) {
+    public func updateAvailableFilters(_ availableFilters: [ChatListContainerNodeFilter], limit: Int32?, fallbackId: ChatListFilterTabEntryId? = nil) {
         if self.availableFilters != availableFilters {
             let apply: () -> Void = { [weak self] in
                 guard let strongSelf = self else {
@@ -904,13 +904,20 @@ public final class ChatListContainerNode: ASDisplayNode, ASGestureRecognizerDele
                     strongSelf.update(layout: layout, navigationBarHeight: navigationBarHeight, visualNavigationHeight: visualNavigationHeight, originalNavigationHeight: originalNavigationHeight, cleanNavigationBarHeight: cleanNavigationBarHeight, insets: insets, isReorderingFilters: isReorderingFilters, isEditing: isEditing, inlineNavigationLocation: inlineNavigationLocation, inlineNavigationTransitionFraction: inlineNavigationTransitionFraction, storiesInset: storiesInset, transition: .immediate)
                 }
             }
+            if let pendingId = self.pendingItemNode?.0, !availableFilters.contains(where: { $0.id == pendingId }) {
+                self.pendingItemNode?.2.dispose()
+                self.pendingItemNode = nil
+            }
             if !availableFilters.contains(where: { $0.id == self.selectedId }) {
-                // MARK: NAGRAM — Fall back to a filter that remains visible when All Chats is hidden.
-                if let fallbackId = availableFilters.first?.id {
-                    apply()
-                    self.switchToFilter(id: fallbackId, animated: false)
-                } else {
-                    apply()
+                // MARK: NAGRAM — Apply the controller's resolved fallback and cancel stale pending switches.
+                let resolvedFallbackId = fallbackId.flatMap { id in
+                    return availableFilters.contains(where: { $0.id == id }) ? id : nil
+                } ?? availableFilters.first?.id
+                self.pendingItemNode?.2.dispose()
+                self.pendingItemNode = nil
+                apply()
+                if let resolvedFallbackId {
+                    self.switchToFilter(id: resolvedFallbackId, animated: false)
                 }
             } else {
                 apply()
@@ -930,6 +937,10 @@ public final class ChatListContainerNode: ASDisplayNode, ASGestureRecognizerDele
     
     public func switchToFilter(id: ChatListFilterTabEntryId, animated: Bool = true, completion: (() -> Void)? = nil) {
         self.onFilterSwitch?()
+        if let pendingItemNode = self.pendingItemNode, pendingItemNode.0 != id {
+            pendingItemNode.2.dispose()
+            self.pendingItemNode = nil
+        }
         if id != self.selectedId, let index = self.availableFilters.firstIndex(where: { $0.id == id }) {
             if let itemNode = self.itemNodes[id] {
                 guard let (layout, navigationBarHeight, visualNavigationHeight, originalNavigationHeight, cleanNavigationBarHeight, insets, isReorderingFilters, isEditing, inlineNavigationLocation, inlineNavigationTransitionFraction, storiesInset) = self.validLayout else {


### PR DESCRIPTION
## Summary

- use the controller's resolved folder as the single fallback target when the current filter disappears
- cancel stale pending filter nodes before they can overwrite a newer selection
- preserve the existing two-argument updateAvailableFilters API through a defaulted fallback parameter

Follow-up to #36.

## Validation

- xcrun swiftc -frontend -parse passed for ChatListController.swift, ChatListControllerNode.swift, and PeerSelectionController.swift
- targeted state assertions passed for hidden All Chats, deleted current folders, removed pending targets, and reselecting the current tab while another target is pending
- all updateAvailableFilters call sites checked; the PeerSelectionController two-argument call remains source-compatible
- independent final review: no P1/P2 findings

Full debug_sim_arm64 build was not available because build-system/bazel-rules/sourcekit-bazel-bsp lacks a MODULE.bazel, REPO.bazel, or WORKSPACE file in this workspace.

## Upstream touch notes

Both modified ChatListUI files retain nearby MARK: NAGRAM annotations for rebase tracking.
