### PR TITLE
fix: show Archive/Unarchive in chat list long-press menu

### DIFF
--- a/submodules/ChatListUI/Sources/ChatContextMenus.swift
+++ b/submodules/ChatListUI/Sources/ChatContextMenus.swift
@@ -379,7 +379,7 @@ func chatContextMenuItems(context: AccountContext, peerId: EnginePeer.Id, promoI
                             }
                         }
                         
-                        let archiveEnabled = !isSavedMessages && peerId != EnginePeer.Id(namespace: Namespaces.Peer.CloudUser, id: EnginePeer.Id.Id._internalFromInt64Value(777000)) && peerId == context.account.peerId
+                        let archiveEnabled = !isSavedMessages && peerId != EnginePeer.Id(namespace: Namespaces.Peer.CloudUser, id: EnginePeer.Id.Id._internalFromInt64Value(777000))
                         if let group = peerGroup {
                             if archiveEnabled {
                                 let isArchived = group == .archive

--- a/submodules/ChatListUI/Sources/ChatContextMenus.swift
+++ b/submodules/ChatListUI/Sources/ChatContextMenus.swift
@@ -379,7 +379,7 @@ func chatContextMenuItems(context: AccountContext, peerId: EnginePeer.Id, promoI
                             }
                         }
                         
-                        let archiveEnabled = !isSavedMessages && peerId != EnginePeer.Id(namespace: Namespaces.Peer.CloudUser, id: EnginePeer.Id.Id._internalFromInt64Value(777000))
+                        let archiveEnabled = !isSavedMessages && peerId != EnginePeer.Id(namespace: Namespaces.Peer.CloudUser, id: EnginePeer.Id.Id._internalFromInt64Value(777000)) // MARK: NAGRAM
                         if let group = peerGroup {
                             if archiveEnabled {
                                 let isArchived = group == .archive


### PR DESCRIPTION
## Summary
- Fixes chat list long-press context menu so **Archive / Unarchive** actually appears for normal chats.
- When a chat is in the archive, long-press now offers **Unarchive** (`ChatList_Context_Unarchive`) and moves it back to the main list via `updatePeersGroupIdInteractively`.

## Problem
`archiveEnabled` was computed as:

```swift
!isSavedMessages && peerId != serviceNotifications && peerId == context.account.peerId
```

But `isSavedMessages` is already `peerId == context.account.peerId`, so the condition is always false. Archive/Unarchive never showed on long-press (including for archived chats).

Same bug is tracked upstream as TelegramMessenger/Telegram-iOS#1382.

## Change
Remove the contradictory `&& peerId == context.account.peerId` check in `ChatContextMenus.swift`. Existing logic already:
- hides the action for Saved Messages and service notifications (`777000`)
- labels the action Unarchive when `group == .archive`
- unarchives with `updatePeersGroupIdInteractively(..., groupId: .root)`

## Test plan
- [ ] Open **Archived Chats**
- [ ] Long-press an archived chat
- [ ] Confirm **Unarchive** is in the menu
- [ ] Tap it and confirm the chat leaves the archive
- [ ] Long-press a normal (non-archived) chat and confirm **Archive** still appears (except Saved Messages / service notifications)