### PR TITLE
fix: prevent folder tab emoji icons from being clipped

### DIFF
--- a/submodules/TelegramUI/Components/HorizontalTabsComponent/Sources/HorizontalTabsComponent.swift
+++ b/submodules/TelegramUI/Components/HorizontalTabsComponent/Sources/HorizontalTabsComponent.swift
@@ -1122,8 +1122,8 @@ private final class ItemComponent: Component {
                         animationRenderer: component.context?.animationRenderer,
                         placeholderColor: component.theme.chat.inputPanel.panelControlColor.withMultipliedAlpha(0.1),
                         text: .plain(titleString),
-                        displaysAsynchronously: false,
-                        insets: UIEdgeInsets(top: titleInset, left: 0.0, bottom: titleInset, right: 0.0)
+                        insets: UIEdgeInsets(top: titleInset, left: 0.0, bottom: titleInset, right: 0.0),
+                        displaysAsynchronously: false
                     )),
                     environment: {},
                     containerSize: CGSize(width: 300.0, height: 100.0)

--- a/submodules/TelegramUI/Components/HorizontalTabsComponent/Sources/HorizontalTabsComponent.swift
+++ b/submodules/TelegramUI/Components/HorizontalTabsComponent/Sources/HorizontalTabsComponent.swift
@@ -1112,6 +1112,8 @@ private final class ItemComponent: Component {
                     .foregroundColor: component.theme.chat.inputPanel.panelControlColor
                 ], range: NSRange(location: 0, length: titleString.length))
                 
+                // MARK: NAGRAM - Give emoji glyphs vertical room so folder-tab icons are not clipped by the text bounds.
+                let titleInset: CGFloat = 4.0
                 titleContentSize = titleContent.update(
                     transition: .immediate,
                     component: AnyComponent(MultilineTextWithEntitiesComponent(
@@ -1120,7 +1122,8 @@ private final class ItemComponent: Component {
                         animationRenderer: component.context?.animationRenderer,
                         placeholderColor: component.theme.chat.inputPanel.panelControlColor.withMultipliedAlpha(0.1),
                         text: .plain(titleString),
-                        displaysAsynchronously: false
+                        displaysAsynchronously: false,
+                        insets: UIEdgeInsets(top: titleInset, left: 0.0, bottom: titleInset, right: 0.0)
                     )),
                     environment: {},
                     containerSize: CGSize(width: 300.0, height: 100.0)


### PR DESCRIPTION
## Summary
- Folder tab bar emoji icons were clipped at the top and bottom.
- Align with `ChatListFilterTabContainerNode` by giving `MultilineTextWithEntitiesComponent` 4pt top/bottom insets so emoji glyphs keep their full vertical bounds.

## Test plan
- [ ] Open chat list with folders that use emoji titles or icons
- [ ] Confirm emoji glyphs in the folder tab bar are no longer truncated top/bottom
- [ ] Switch between folders and verify layout still centers correctly
- [ ] Check selected/unselected states and badge-adjacent tabs