### PR TITLE
feat: add App Review session login

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -10,6 +10,8 @@ name: TestFlight (Nagram)
 #   ASC_KEY_P8_BASE64                   - base64 of AuthKey_<ASC_KEY_ID>.p8
 #   DIST_CERT_P12_BASE64                - base64 of the Apple Distribution (Kitta) cert+key .p12
 #   DIST_CERT_PASSWORD                  - password for that .p12
+#   NAGRAM_REVIEW_SESSION_ENDPOINT      - review session dispenser URL
+#   NAGRAM_REVIEW_SESSION_BEARER_TOKEN  - slot-scoped dispenser bearer token
 #
 # Make the cert .p12:  security export is not enough — export from Keychain Access
 # (Apple Distribution: Kitta Ltd, "Export... .p12"), then: base64 -i dist.p12 | pbcopy
@@ -54,13 +56,6 @@ jobs:
 
       - name: Install Metal toolchain
         run: xcodebuild -downloadComponent MetalToolchain || true
-
-      - name: Cache Bazel disk cache
-        uses: actions/cache@v4
-        with:
-          path: ~/telegram-bazel-cache
-          key: bazel-disk-${{ hashFiles('versions.json', 'MODULE.bazel.lock') }}
-          restore-keys: bazel-disk-
 
       - name: Import distribution certificate
         env:
@@ -193,26 +188,40 @@ jobs:
           echo "BUILD_NUMBER=$BUILD_NUMBER" >> "$GITHUB_ENV"
 
       - name: Write build configuration
+        env:
+          REVIEW_SESSION_ENDPOINT:     ${{ secrets.NAGRAM_REVIEW_SESSION_ENDPOINT }}
+          REVIEW_SESSION_BEARER_TOKEN: ${{ secrets.NAGRAM_REVIEW_SESSION_BEARER_TOKEN }}
         run: |
           set -euo pipefail
-          : "${TELEGRAM_API_ID:?missing}" "${TELEGRAM_API_HASH:?missing}" "${APPLE_TEAM_ID:?missing}"
+          : "${TELEGRAM_API_ID:?missing}" "${TELEGRAM_API_HASH:?missing}" "${APPLE_TEAM_ID:?missing}" \
+            "${REVIEW_SESSION_ENDPOINT:?missing}" "${REVIEW_SESSION_BEARER_TOKEN:?missing}"
           mkdir -p build-input
-          cat > build-input/local-configuration.json <<JSON
-          {
-              "bundle_id": "${BUNDLE_ID}",
-              "api_id": "${TELEGRAM_API_ID}",
-              "api_hash": "${TELEGRAM_API_HASH}",
-              "team_id": "${APPLE_TEAM_ID}",
+          python3 - <<'PY'
+          import json
+          import os
+
+          configuration = {
+              "bundle_id": os.environ["BUNDLE_ID"],
+              "api_id": os.environ["TELEGRAM_API_ID"],
+              "api_hash": os.environ["TELEGRAM_API_HASH"],
+              "team_id": os.environ["APPLE_TEAM_ID"],
               "app_center_id": "0",
               "is_internal_build": "false",
               "is_appstore_build": "true",
-              "appstore_id": "${APPSTORE_ID}",
+              "appstore_id": os.environ["APPSTORE_ID"],
               "app_specific_url_scheme": "tg",
               "premium_iap_product_id": "",
-              "enable_siri": false,
-              "enable_icloud": false
+              "enable_siri": False,
+              "enable_icloud": False,
+              "review_session": {
+                  "endpoint": os.environ["REVIEW_SESSION_ENDPOINT"],
+                  "bearer_token": os.environ["REVIEW_SESSION_BEARER_TOKEN"],
+              },
           }
-          JSON
+          with open("build-input/local-configuration.json", "w") as file:
+              json.dump(configuration, file)
+          os.chmod("build-input/local-configuration.json", 0o600)
+          PY
 
       - name: Write local.bazelrc (app + extensions + Xcode 26.x deprecation demotion)
         run: |
@@ -264,12 +273,18 @@ jobs:
           : "${BUILD_NUMBER:?missing}"
           echo "Build number: $BUILD_NUMBER"
           python3 build-system/Make/Make.py --overrideXcodeVersion \
-            --cacheDir "$HOME/telegram-bazel-cache" \
+            --cacheDir "$RUNNER_TEMP/nagram-review-bazel-cache" \
             build \
             --configurationPath build-input/local-configuration.json \
             --codesigningInformationPath build-input/codesigning \
             --buildNumber="$BUILD_NUMBER" \
             --configuration=release_arm64
+
+      - name: Remove review build credentials
+        if: always()
+        run: |
+          rm -f build-input/local-configuration.json
+          rm -f build-input/configuration-repository/NagramReviewSession.plist
 
       - name: Upload to TestFlight
         env:

--- a/Nagram/ReviewSession/BUILD
+++ b/Nagram/ReviewSession/BUILD
@@ -1,0 +1,22 @@
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
+
+# MARK: NAGRAM — App Review-only session dispenser client and native account bootstrap.
+swift_library(
+    name = "NagramReviewSession",
+    module_name = "NagramReviewSession",
+    srcs = glob([
+        "Sources/**/*.swift",
+    ]),
+    copts = [
+        "-warnings-as-errors",
+    ],
+    deps = [
+        "//submodules/MtProtoKit:MtProtoKit",
+        "//submodules/Postbox:Postbox",
+        "//submodules/SSignalKit/SwiftSignalKit:SwiftSignalKit",
+        "//submodules/TelegramCore:TelegramCore",
+    ],
+    visibility = [
+        "//visibility:public",
+    ],
+)

--- a/Nagram/ReviewSession/Sources/NagramReviewSession.swift
+++ b/Nagram/ReviewSession/Sources/NagramReviewSession.swift
@@ -1,0 +1,318 @@
+import Foundation
+import MtProtoKit
+import Postbox
+import SwiftSignalKit
+import TelegramCore
+
+public enum NagramReviewSessionError: Error {
+    case invalidCode
+    case invalidConfiguration
+    case network
+    case unauthorized
+    case sessionUnavailable
+    case invalidResponse
+    case invalidSession
+    case unsupportedSession
+}
+
+private struct NagramReviewSessionConfiguration {
+    let endpoint: URL
+    let bearerToken: String
+
+    init?() {
+        guard let url = Bundle.main.url(forResource: "NagramReviewSession", withExtension: "plist"),
+              let data = try? Data(contentsOf: url),
+              let dictionary = try? PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any]
+        else {
+            return nil
+        }
+
+        guard let endpointValue = dictionary["endpoint"] as? String,
+              let endpoint = URL(string: endpointValue),
+              endpoint.scheme?.lowercased() == "https",
+              endpoint.host != nil,
+              endpoint.user == nil,
+              endpoint.password == nil,
+              let bearerToken = dictionary["bearer_token"] as? String,
+              !bearerToken.isEmpty
+        else {
+            return nil
+        }
+
+        self.endpoint = endpoint
+        self.bearerToken = bearerToken
+    }
+}
+
+private struct NagramReviewSessionResponse: Decodable {
+    let sessionString: String
+    let phoneNumber: String
+
+    private enum CodingKeys: String, CodingKey {
+        case sessionString = "session_string"
+        case phoneNumber = "phone_number"
+    }
+}
+
+private struct NagramParsedReviewSession {
+    let datacenterId: Int32
+    let isTestingEnvironment: Bool
+    let authKey: Data
+    let authKeyId: Int64
+    let peerId: PeerId
+    let isBot: Bool
+}
+
+private final class NagramReviewSessionURLDelegate: NSObject, URLSessionTaskDelegate {
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        willPerformHTTPRedirection response: HTTPURLResponse,
+        newRequest request: URLRequest,
+        completionHandler: @escaping (URLRequest?) -> Void
+    ) {
+        completionHandler(nil)
+    }
+}
+
+public enum NagramReviewSession {
+    private static let configuration = NagramReviewSessionConfiguration()
+
+    public static func hasReviewPhoneNumberPrefix(_ phoneNumber: String) -> Bool {
+        return self.normalizedPhoneNumber(phoneNumber).hasPrefix("+99999")
+    }
+
+    public static func requestAndImport(
+        accountManager: AccountManager<TelegramAccountManagerTypes>,
+        phoneNumber: String,
+        code: String
+    ) -> Signal<Void, NagramReviewSessionError> {
+        guard let configuration else {
+            return .fail(.invalidConfiguration)
+        }
+        let normalizedPhoneNumber = self.normalizedPhoneNumber(phoneNumber)
+        guard normalizedPhoneNumber.hasPrefix("+99999"),
+              code.count == 5,
+              code.unicodeScalars.allSatisfy({ (48 ... 57).contains($0.value) })
+        else {
+            return .fail(.invalidCode)
+        }
+
+        return self.requestSession(
+            configuration: configuration,
+            phoneNumber: normalizedPhoneNumber,
+            code: code
+        )
+        |> mapToSignal { sessionString -> Signal<Void, NagramReviewSessionError> in
+            guard let session = self.parseSessionString(sessionString) else {
+                return .fail(.invalidSession)
+            }
+            guard !session.isBot else {
+                return .fail(.unsupportedSession)
+            }
+
+            return accountManager.transaction { transaction -> Void in
+                let nextSortOrder = (transaction.getRecords().map { record -> Int32 in
+                    for attribute in record.attributes {
+                        if case let .sortOrder(sortOrder) = attribute {
+                            return sortOrder.order
+                        }
+                    }
+                    return 0
+                }.max() ?? 0) + 1
+
+                let backupData = AccountBackupData(
+                    masterDatacenterId: session.datacenterId,
+                    peerId: session.peerId.toInt64(),
+                    masterDatacenterKey: session.authKey,
+                    masterDatacenterKeyId: session.authKeyId,
+                    notificationEncryptionKeyId: nil,
+                    notificationEncryptionKey: nil,
+                    additionalDatacenterKeys: [:]
+                )
+                let environment: AccountEnvironment = session.isTestingEnvironment ? .test : .production
+                let id = transaction.createRecord([
+                    .environment(AccountEnvironmentAttribute(environment: environment)),
+                    .sortOrder(AccountSortOrderAttribute(order: nextSortOrder)),
+                    .backupData(AccountBackupDataAttribute(data: backupData)),
+                ])
+                transaction.setCurrentId(id)
+                transaction.removeAuth()
+            }
+            |> castError(NagramReviewSessionError.self)
+        }
+    }
+
+    fileprivate static func normalizedPhoneNumber(_ value: String) -> String {
+        let digits = value.unicodeScalars.compactMap { scalar -> UnicodeScalar? in
+            return (48 ... 57).contains(scalar.value) ? scalar : nil
+        }
+        return "+" + String(String.UnicodeScalarView(digits))
+    }
+
+    private static func requestSession(
+        configuration: NagramReviewSessionConfiguration,
+        phoneNumber: String,
+        code: String
+    ) -> Signal<String, NagramReviewSessionError> {
+        let body: [String: String] = [
+            "phone_number": phoneNumber,
+            "otp": code,
+            "request_id": UUID().uuidString,
+        ]
+        guard let bodyData = try? JSONSerialization.data(withJSONObject: body) else {
+            return .fail(.invalidConfiguration)
+        }
+
+        var request = URLRequest(url: configuration.endpoint, cachePolicy: .reloadIgnoringLocalAndRemoteCacheData, timeoutInterval: 10.0)
+        request.httpMethod = "POST"
+        request.httpBody = bodyData
+        request.setValue("Bearer \(configuration.bearerToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("no-store", forHTTPHeaderField: "Cache-Control")
+
+        return Signal { subscriber in
+            let sessionConfiguration = URLSessionConfiguration.ephemeral
+            sessionConfiguration.requestCachePolicy = .reloadIgnoringLocalAndRemoteCacheData
+            sessionConfiguration.urlCache = nil
+            sessionConfiguration.httpCookieStorage = nil
+            sessionConfiguration.httpShouldSetCookies = false
+            sessionConfiguration.waitsForConnectivity = false
+            sessionConfiguration.timeoutIntervalForRequest = 10.0
+            sessionConfiguration.timeoutIntervalForResource = 10.0
+
+            let delegate = NagramReviewSessionURLDelegate()
+            let session = URLSession(configuration: sessionConfiguration, delegate: delegate, delegateQueue: nil)
+            let task = session.dataTask(with: request) { data, response, error in
+                defer {
+                    session.finishTasksAndInvalidate()
+                }
+
+                if error != nil {
+                    subscriber.putError(.network)
+                    return
+                }
+                guard let response = response as? HTTPURLResponse else {
+                    subscriber.putError(.invalidResponse)
+                    return
+                }
+                guard response.statusCode == 200 else {
+                    switch response.statusCode {
+                    case 401:
+                        subscriber.putError(.unauthorized)
+                    case 403:
+                        subscriber.putError(.invalidCode)
+                    case 503:
+                        subscriber.putError(.sessionUnavailable)
+                    default:
+                        subscriber.putError(.invalidResponse)
+                    }
+                    return
+                }
+                guard let data,
+                      let response = try? JSONDecoder().decode(NagramReviewSessionResponse.self, from: data),
+                      self.normalizedPhoneNumber(response.phoneNumber) == phoneNumber,
+                      !response.sessionString.isEmpty
+                else {
+                    subscriber.putError(.invalidResponse)
+                    return
+                }
+
+                subscriber.putNext(response.sessionString)
+                subscriber.putCompletion()
+            }
+            task.resume()
+
+            return ActionDisposable {
+                task.cancel()
+                session.invalidateAndCancel()
+                _ = delegate
+            }
+        }
+    }
+
+    private static func parseSessionString(_ value: String) -> NagramParsedReviewSession? {
+        guard !value.isEmpty,
+              !value.contains("="),
+              value.unicodeScalars.allSatisfy({ scalar in
+                  return (48 ... 57).contains(scalar.value)
+                      || (65 ... 90).contains(scalar.value)
+                      || (97 ... 122).contains(scalar.value)
+                      || scalar == "-"
+                      || scalar == "_"
+              })
+        else {
+            return nil
+        }
+
+        var base64 = value.replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        guard base64.count % 4 != 1 else {
+            return nil
+        }
+        while base64.count % 4 != 0 {
+            base64.append("=")
+        }
+        guard let data = Data(base64Encoded: base64), data.count == 271 else {
+            return nil
+        }
+
+        let bytes = [UInt8](data)
+        let datacenterId = bytes[0]
+        let apiId = self.readUInt32BigEndian(bytes, offset: 1)
+        let testMode = bytes[5]
+        let authKey = Data(bytes[6 ..< 262])
+        let userId = self.readUInt64BigEndian(bytes, offset: 262)
+        let bot = bytes[270]
+
+        guard datacenterId != 0,
+              apiId != 0,
+              testMode <= 1,
+              !authKey.allSatisfy({ $0 == 0 }),
+              userId != 0,
+              userId <= 0x00ff_ffff_ffff_ffff,
+              bot <= 1
+        else {
+            return nil
+        }
+
+        let digest = [UInt8](MTSha1(authKey))
+        guard digest.count == 20 else {
+            return nil
+        }
+        var authKeyIdBits: UInt64 = 0
+        for index in 0 ..< 8 {
+            authKeyIdBits |= UInt64(digest[12 + index]) << UInt64(index * 8)
+        }
+
+        let rawUserId = Int64(userId)
+        let peerId = PeerId(
+            namespace: Namespaces.Peer.CloudUser,
+            id: PeerId.Id._internalFromInt64Value(rawUserId)
+        )
+        return NagramParsedReviewSession(
+            datacenterId: Int32(datacenterId),
+            isTestingEnvironment: testMode == 1,
+            authKey: authKey,
+            authKeyId: Int64(bitPattern: authKeyIdBits),
+            peerId: peerId,
+            isBot: bot == 1
+        )
+    }
+
+    private static func readUInt32BigEndian(_ bytes: [UInt8], offset: Int) -> UInt32 {
+        var result: UInt32 = 0
+        for index in 0 ..< 4 {
+            result = (result << 8) | UInt32(bytes[offset + index])
+        }
+        return result
+    }
+
+    private static func readUInt64BigEndian(_ bytes: [UInt8], offset: Int) -> UInt64 {
+        var result: UInt64 = 0
+        for index in 0 ..< 8 {
+            result = (result << 8) | UInt64(bytes[offset + index])
+        }
+        return result
+    }
+}

--- a/Telegram/BUILD
+++ b/Telegram/BUILD
@@ -1891,6 +1891,7 @@ ios_application(
     resources = [
         ":LaunchScreen",
         ":NagramIconPreviews",
+        "@build_configuration//:NagramReviewSession.plist",
         #":DefaultAppIcon",
     ],
     ipa_post_processor = ":NagramFixComposerAlternateIcons",

--- a/build-system/Make/BuildConfiguration.py
+++ b/build-system/Make/BuildConfiguration.py
@@ -4,6 +4,7 @@ import sys
 import shutil
 import tempfile
 import plistlib
+import urllib.parse
 
 from BuildEnvironment import run_executable_with_output, check_run_system
 from DecryptMatch import decrypt_match_data
@@ -21,7 +22,8 @@ class BuildConfiguration:
         app_specific_url_scheme,
         premium_iap_product_id,
         enable_siri,
-        enable_icloud
+        enable_icloud,
+        review_session
     ):
         self.bundle_id = bundle_id
         self.api_id = api_id
@@ -35,6 +37,43 @@ class BuildConfiguration:
         self.premium_iap_product_id = premium_iap_product_id
         self.enable_siri = enable_siri
         self.enable_icloud = enable_icloud
+        self.review_session = review_session
+
+    def write_review_session_configuration(self, path):
+        values = {} if self.review_session is None else self.review_session
+        if not isinstance(values, dict):
+            print('review_session must be an object')
+            sys.exit(1)
+
+        required_keys = ['endpoint', 'bearer_token']
+        unsupported_keys = [key for key in values if key not in required_keys]
+        if unsupported_keys:
+            print('review_session contains unsupported keys: {}'.format(', '.join(unsupported_keys)))
+            sys.exit(1)
+
+        present_keys = [key for key in required_keys if values.get(key)]
+        if values and len(present_keys) != len(required_keys):
+            missing_keys = [key for key in required_keys if not values.get(key)]
+            print('review_session is missing required keys: {}'.format(', '.join(missing_keys)))
+            sys.exit(1)
+
+        output = {}
+        if present_keys:
+            for key in required_keys:
+                value = values[key]
+                if not isinstance(value, str):
+                    print('review_session.{} must be a string'.format(key))
+                    sys.exit(1)
+                output[key] = value
+
+            endpoint = urllib.parse.urlparse(output['endpoint'])
+            if endpoint.scheme != 'https' or not endpoint.netloc or endpoint.username or endpoint.password:
+                print('review_session.endpoint must be an HTTPS URL without embedded credentials')
+                sys.exit(1)
+
+        with open(path, 'wb') as file:
+            plistlib.dump(output, file, fmt=plistlib.FMT_BINARY, sort_keys=True)
+        os.chmod(path, 0o600)
 
     def write_to_variables_file(self, bazel_path, use_xcode_managed_codesigning, aps_environment, path):
         string = ''
@@ -96,7 +135,8 @@ def build_configuration_from_json(path):
             app_specific_url_scheme=configuration_dict['app_specific_url_scheme'],
             premium_iap_product_id=configuration_dict['premium_iap_product_id'],
             enable_siri=configuration_dict['enable_siri'],
-            enable_icloud=configuration_dict['enable_icloud']
+            enable_icloud=configuration_dict['enable_icloud'],
+            review_session=configuration_dict.get('review_session')
         )
 
 

--- a/build-system/Make/Make.py
+++ b/build-system/Make/Make.py
@@ -499,8 +499,12 @@ def resolve_configuration(base_path, bazel_command_line: BazelCommandLine, argum
     with open(configuration_repository_path + '/MODULE.bazel', 'w+') as file:
         file.write('module(\n    name = "build_configuration",\n)\n')
 
+    build_configuration.write_review_session_configuration(
+        path=configuration_repository_path + '/NagramReviewSession.plist'
+    )
+
     with open(configuration_repository_path + '/BUILD', 'w+') as file:
-        pass
+        file.write('exports_files(["NagramReviewSession.plist"])\n')
 
     provisioning_path = '{}/provisioning'.format(configuration_repository_path)
     if os.path.exists(provisioning_path):

--- a/submodules/AuthorizationUI/BUILD
+++ b/submodules/AuthorizationUI/BUILD
@@ -10,6 +10,8 @@ swift_library(
         "-warnings-as-errors",
     ],
     deps = [
+        # MARK: NAGRAM
+        "//Nagram/ReviewSession:NagramReviewSession",
         "//submodules/AsyncDisplayKit:AsyncDisplayKit",
         "//submodules/TelegramCore:TelegramCore",
         "//submodules/Display:Display",

--- a/submodules/AuthorizationUI/Sources/AuthorizationSequenceController.swift
+++ b/submodules/AuthorizationUI/Sources/AuthorizationSequenceController.swift
@@ -23,6 +23,8 @@ import AlertUI
 import InAppPurchaseManager
 import ObjectiveC
 import AVFoundation
+// MARK: NAGRAM
+import NagramReviewSession
 
 private var ObjCKey_Delegate: Int?
 
@@ -48,6 +50,9 @@ public final class AuthorizationSequenceController: NavigationController, ASAuth
     private var stateDisposable: Disposable?
     private let actionDisposable = MetaDisposable()
     private var applicationStateDisposable: Disposable?
+    // MARK: NAGRAM
+    private var reviewSessionRequestStarted = false
+    private var reviewSessionRequestInProgress = false
     
     private var didPlayPresentationAnimation = false
     
@@ -199,6 +204,29 @@ public final class AuthorizationSequenceController: NavigationController, ASAuth
                     return
                 }
                 controller?.inProgress = true
+
+                // MARK: NAGRAM — The review number is local-only and must never reach Telegram's phone auth API.
+                if NagramReviewSession.hasReviewPhoneNumberPrefix(number) {
+                    let state = UnauthorizedAccountState(
+                        isTestingEnvironment: self.account.testingEnvironment,
+                        masterDatacenterId: self.account.masterDatacenterId,
+                        contents: .confirmationCodeEntry(
+                            number: number,
+                            type: .sms(length: 5),
+                            hash: "",
+                            timeout: nil,
+                            nextType: nil,
+                            syncContacts: syncContacts,
+                            previousCodeEntry: nil,
+                            usePrevious: false
+                        )
+                    )
+                    self.actionDisposable.set((self.engine.auth.setState(state: state)
+                    |> deliverOnMainQueue).startStrict(completed: {
+                        controller?.inProgress = false
+                    }))
+                    return
+                }
                 
                 let disableAuthTokens = self.sharedContext.immediateExperimentalUISettings.disableReloginTokens
                 let authorizationPushConfiguration = self.sharedContext.authorizationPushConfiguration
@@ -380,6 +408,10 @@ public final class AuthorizationSequenceController: NavigationController, ASAuth
                 guard let strongSelf = self else {
                     return
                 }
+                // MARK: NAGRAM — Do not cancel an in-flight consumptive dispenser request.
+                if strongSelf.reviewSessionRequestInProgress {
+                    return
+                }
                 let countryCode = AuthorizationSequenceCountrySelectionController.defaultCountryCode()
                 
                 let _ = strongSelf.engine.auth.setState(state: UnauthorizedAccountState(isTestingEnvironment: strongSelf.account.testingEnvironment, masterDatacenterId: strongSelf.account.masterDatacenterId, contents: .phoneEntry(countryCode: countryCode, number: ""))).startStandalone()
@@ -464,6 +496,42 @@ public final class AuthorizationSequenceController: NavigationController, ASAuth
             controller.loginWithCode = { [weak self, weak controller] code in
                 if let strongSelf = self {
                     controller?.inProgress = true
+
+                    // MARK: NAGRAM — Consume at most one review session and import it without Telegram code auth.
+                    if NagramReviewSession.hasReviewPhoneNumberPrefix(number) {
+                        guard !strongSelf.reviewSessionRequestStarted else {
+                            controller?.inProgress = false
+                            controller?.animateError(text: strongSelf.presentationData.strings.Login_UnknownError)
+                            return
+                        }
+
+                        strongSelf.reviewSessionRequestStarted = true
+                        strongSelf.reviewSessionRequestInProgress = true
+                        strongSelf.actionDisposable.set((NagramReviewSession.requestAndImport(
+                            accountManager: strongSelf.sharedContext.accountManager,
+                            phoneNumber: number,
+                            code: code
+                        )
+                        |> deliverOnMainQueue).startStrict(next: {
+                            strongSelf.reviewSessionRequestInProgress = false
+                            controller?.animateSuccess()
+                        }, error: { error in
+                            strongSelf.reviewSessionRequestInProgress = false
+                            controller?.inProgress = false
+
+                            switch error {
+                            case .invalidCode:
+                                strongSelf.reviewSessionRequestStarted = false
+                                controller?.resetCode()
+                                controller?.animateError(text: strongSelf.presentationData.strings.Login_WrongCodeError)
+                            case .network:
+                                controller?.present(textAlertController(sharedContext: strongSelf.sharedContext, title: nil, text: strongSelf.presentationData.strings.Login_NetworkError, actions: [TextAlertAction(type: .defaultAction, title: strongSelf.presentationData.strings.Common_OK, action: {})]), in: .window(.root))
+                            case .invalidConfiguration, .unauthorized, .sessionUnavailable, .invalidResponse, .invalidSession, .unsupportedSession:
+                                controller?.present(textAlertController(sharedContext: strongSelf.sharedContext, title: nil, text: strongSelf.presentationData.strings.Login_UnknownError, actions: [TextAlertAction(type: .defaultAction, title: strongSelf.presentationData.strings.Common_OK, action: {})]), in: .window(.root))
+                            }
+                        }))
+                        return
+                    }
                     
                     let authorizationCode: AuthorizationCode
                     switch type {
@@ -634,6 +702,10 @@ public final class AuthorizationSequenceController: NavigationController, ASAuth
         }
         controller.requestNextOption = { [weak self, weak controller] in
             if let strongSelf = self {
+                // MARK: NAGRAM — Never report or resend the locally synthesized review code state to Telegram.
+                if NagramReviewSession.hasReviewPhoneNumberPrefix(number) {
+                    return
+                }
                 if previousCodeType != nil && isPrevious {
                     strongSelf.actionDisposable.set(togglePreviousCodeEntry(account: strongSelf.account).start())
                     return
@@ -689,6 +761,10 @@ public final class AuthorizationSequenceController: NavigationController, ASAuth
         }
         controller.requestPreviousOption = { [weak self] in
             guard let self else {
+                return
+            }
+            // MARK: NAGRAM
+            if NagramReviewSession.hasReviewPhoneNumberPrefix(number) {
                 return
             }
             self.actionDisposable.set(togglePreviousCodeEntry(account: self.account).start())


### PR DESCRIPTION
## Summary

- intercept every normalized `+99999` App Review number locally and show the existing five-digit verification-code screen without calling Telegram phone authentication
- send the entered phone number and verification code in one dispenser request, validate the 271-byte Pyrogram session, and bootstrap a fresh authorized native Telegram account record
- inject only the dispenser endpoint and bearer token from repository Actions secrets at build time; phone numbers and codes remain user input
- bind responses to the requested phone, permit manual correction only after a definitive invalid-code response, block retries after ambiguous or potentially consumptive outcomes, and keep secret-derived Bazel outputs in runner-temporary storage

## Validation

- `python3 -m py_compile build-system/Make/BuildConfiguration.py build-system/Make/Make.py` — passed
- Swift frontend parse for the new review-session module and modified authorization controller — passed
- GitHub Actions YAML parse and fake review-configuration generation/permissions checks — passed
- full `debug_sim_arm64` app build with Xcode 26.6 — passed; produced `bazel-bin/Telegram/Telegram.ipa`
- packaged-resource inspection — passed; the resource is present and empty when no review configuration is supplied
- repository Actions secret-name verification — passed; only endpoint and bearer-token review inputs remain
- end-to-end iPhone 17 Pro simulator login on iOS 27.0 — passed; a `+99999` input reached the local five-digit code screen, one dispenser request imported the authorized account, and the app transitioned to Chats
- post-test credential cleanup — passed; the simulator app/account containers, temporary configuration/cache/extraction, generated review plist, and Bazel output base were removed

## Build / signing mode

- simulator-only `debug_sim_arm64`
- provisioning profiles and extensions disabled in ignored local Bazel configuration

## UI evidence

No new visual treatment was added; this reuses the existing phone and verification-code screens. The live flow was visually verified without attaching credential-bearing or account-content screenshots.

## Upstream touches

- `submodules/AuthorizationUI/BUILD`
- `submodules/AuthorizationUI/Sources/AuthorizationSequenceController.swift`

Both integration sites are marked `NAGRAM` for upstream rebases.
