### PR TITLE
fix: 正则 hide 规则命中最后一条消息时不再自动弹键盘

### DIFF
--- a/submodules/ChatListUI/Sources/Node/ChatListItem.swift
+++ b/submodules/ChatListUI/Sources/Node/ChatListItem.swift
@@ -163,6 +163,7 @@ public enum ChatListItemContent {
         public var displayAsTopicList: Bool
         public var tags: [Tag]
         public var customMessageListData: CustomMessageListData?
+        public var nagramSuppressActivateInput: Bool // MARK: NAGRAM
         
         public init(
             messages: [EngineMessage],
@@ -189,7 +190,8 @@ public enum ChatListItemContent {
             requiresPremiumForMessaging: Bool,
             displayAsTopicList: Bool,
             tags: [Tag],
-            customMessageListData: CustomMessageListData? = nil
+            customMessageListData: CustomMessageListData? = nil,
+            nagramSuppressActivateInput: Bool = false // MARK: NAGRAM
         ) {
             self.messages = messages
             self.peer = peer
@@ -216,6 +218,7 @@ public enum ChatListItemContent {
             self.displayAsTopicList = displayAsTopicList
             self.tags = tags
             self.customMessageListData = customMessageListData
+            self.nagramSuppressActivateInput = nagramSuppressActivateInput // MARK: NAGRAM
         }
     }
     
@@ -629,13 +632,33 @@ public class ChatListItem: ListViewItem {
                 }
                 self.interaction.messageSelected(selectedPeer, threadId, message, peerData.promoInfo)
             } else if let peer = peerData.peer.peer {
+                if self.nagramSelectPeerWithoutActivatingInput(peer, peerData) { // MARK: NAGRAM
+                    return
+                }
                 self.interaction.peerSelected(peer, nil, nil, peerData.promoInfo, false)
             } else if let peer = peerData.peer.peers[peerData.peer.peerId] {
+                if self.nagramSelectPeerWithoutActivatingInput(peer, peerData) { // MARK: NAGRAM
+                    return
+                }
                 self.interaction.peerSelected(peer, nil, nil, peerData.promoInfo, false)
             }
         case let .groupReference(groupReferenceData):
             self.interaction.groupSelected(groupReferenceData.groupId)
         }
+    }
+
+    // MARK: NAGRAM — 预览消息被 hide 规则清空的条目不是真的空会话，走这条路径避免 activateInput 自动弹键盘；
+    // 同时补回 upstream 空会话分支丢掉的 threadId，保证论坛话题仍然进入话题本身。
+    private func nagramSelectPeerWithoutActivatingInput(_ peer: EnginePeer, _ peerData: ChatListItemContent.PeerData) -> Bool {
+        guard peerData.nagramSuppressActivateInput, let action = self.interaction.nagramPeerSelectedWithoutActivatingInput else {
+            return false
+        }
+        var threadId: Int64?
+        if case let .forum(_, _, threadIdValue, _, _) = self.index {
+            threadId = threadIdValue
+        }
+        action(peer, threadId, peerData.promoInfo)
+        return true
     }
         
     static func mergeType(item: ChatListItem, previousItem: ListViewItem?, nextItem: ListViewItem?) -> (first: Bool, last: Bool, firstWithHeader: Bool, nextIsPinned: Bool, nextHasActiveRevealControls: Bool) {

--- a/submodules/ChatListUI/Sources/Node/ChatListNode.swift
+++ b/submodules/ChatListUI/Sources/Node/ChatListNode.swift
@@ -130,6 +130,8 @@ public final class ChatListNodeInteraction {
     let openUrl: (String) -> Void
     
     public var searchTextHighightState: String?
+    // MARK: NAGRAM — hide 规则清空预览消息后走这条路径打开会话，等价于 peerSelected 但不激活输入框。
+    public var nagramPeerSelectedWithoutActivatingInput: ((EnginePeer, Int64?, ChatListNodeEntryPromoInfo?) -> Void)?
     var highlightedChatLocation: ChatListHighlightedLocation?
     
     var isSearchMode: Bool = false
@@ -460,6 +462,7 @@ private func mappedInsertEntries(context: AccountContext, nodeInteraction: ChatL
             let topForumTopicItems = peerEntry.topForumTopicItems
             let revealed = peerEntry.revealed
             let nagramIgnoreUnreadBadge = peerEntry.nagramIgnoreUnreadBadge // MARK: NAGRAM
+            let nagramSuppressActivateInput = peerEntry.nagramSuppressActivateInput // MARK: NAGRAM
         
             switch mode {
                 case .chatList:
@@ -498,7 +501,8 @@ private func mappedInsertEntries(context: AccountContext, nodeInteraction: ChatL
                             },
                             requiresPremiumForMessaging: peerEntry.requiresPremiumForMessaging,
                             displayAsTopicList: peerEntry.displayAsTopicList,
-                            tags: chatListItemTags(location: location, accountPeerId: context.account.peerId, isPremium: isPremium, peer: peer.chatMainPeer, isUnread: (combinedReadState?.isUnread ?? false) && !nagramIgnoreUnreadBadge, isMuted: isRemovedFromTotalUnreadCount, isContact: isContact, hasUnseenMentions: hasUnseenMentions, chatListFilters: chatListFilters)
+                            tags: chatListItemTags(location: location, accountPeerId: context.account.peerId, isPremium: isPremium, peer: peer.chatMainPeer, isUnread: (combinedReadState?.isUnread ?? false) && !nagramIgnoreUnreadBadge, isMuted: isRemovedFromTotalUnreadCount, isContact: isContact, hasUnseenMentions: hasUnseenMentions, chatListFilters: chatListFilters),
+                            nagramSuppressActivateInput: nagramSuppressActivateInput // MARK: NAGRAM
                         )),
                         editing: editing,
                         hasActiveRevealControls: hasActiveRevealControls,
@@ -828,6 +832,7 @@ private func mappedUpdateEntries(context: AccountContext, nodeInteraction: ChatL
                 let topForumTopicItems = peerEntry.topForumTopicItems
                 let revealed = peerEntry.revealed
                 let nagramIgnoreUnreadBadge = peerEntry.nagramIgnoreUnreadBadge // MARK: NAGRAM
+                let nagramSuppressActivateInput = peerEntry.nagramSuppressActivateInput // MARK: NAGRAM
             
                 switch mode {
                     case .chatList:
@@ -866,7 +871,8 @@ private func mappedUpdateEntries(context: AccountContext, nodeInteraction: ChatL
                                 },
                                 requiresPremiumForMessaging: peerEntry.requiresPremiumForMessaging,
                                 displayAsTopicList: peerEntry.displayAsTopicList,
-                                tags: chatListItemTags(location: location, accountPeerId: context.account.peerId, isPremium: isPremium, peer: peer.chatMainPeer, isUnread: (combinedReadState?.isUnread ?? false) && !nagramIgnoreUnreadBadge, isMuted: isRemovedFromTotalUnreadCount, isContact: isContact, hasUnseenMentions: hasUnseenMentions, chatListFilters: chatListFilters)
+                                tags: chatListItemTags(location: location, accountPeerId: context.account.peerId, isPremium: isPremium, peer: peer.chatMainPeer, isUnread: (combinedReadState?.isUnread ?? false) && !nagramIgnoreUnreadBadge, isMuted: isRemovedFromTotalUnreadCount, isContact: isContact, hasUnseenMentions: hasUnseenMentions, chatListFilters: chatListFilters),
+                                nagramSuppressActivateInput: nagramSuppressActivateInput // MARK: NAGRAM
                             )),
                             editing: editing,
                             hasActiveRevealControls: hasActiveRevealControls,
@@ -2810,6 +2816,13 @@ public final class ChatListNode: ListViewImpl {
                 if !refreshStoryPeerIds.isEmpty {
                     strongSelf.context.account.viewTracker.refreshStoryStatsForPeerIds(peerIds: refreshStoryPeerIds)
                 }
+            }
+        }
+        
+        // MARK: NAGRAM — 预览消息被 hide 规则清空的条目按普通消息处理，不要沿用空会话的 activateInput。
+        nodeInteraction.nagramPeerSelectedWithoutActivatingInput = { [weak self] peer, threadId, promoInfo in
+            if let strongSelf = self, let peerSelected = strongSelf.peerSelected {
+                peerSelected(peer, threadId, true, false, promoInfo)
             }
         }
         

--- a/submodules/ChatListUI/Sources/Node/ChatListNodeEntries.swift
+++ b/submodules/ChatListUI/Sources/Node/ChatListNodeEntries.swift
@@ -102,6 +102,7 @@ enum ChatListNodeEntry: Comparable, Identifiable {
         var messages: [EngineMessage]
         var readState: EnginePeerReadCounters?
         var nagramIgnoreUnreadBadge: Bool // MARK: NAGRAM
+        var nagramSuppressActivateInput: Bool // MARK: NAGRAM
         var isRemovedFromTotalUnreadCount: Bool
         var draftState: ChatListItemContent.DraftState?
         var mediaDraftContentType: EngineChatList.MediaDraftContentType?
@@ -133,6 +134,7 @@ enum ChatListNodeEntry: Comparable, Identifiable {
             messages: [EngineMessage],
             readState: EnginePeerReadCounters?,
             nagramIgnoreUnreadBadge: Bool = false, // MARK: NAGRAM
+            nagramSuppressActivateInput: Bool = false, // MARK: NAGRAM
             isRemovedFromTotalUnreadCount: Bool,
             draftState: ChatListItemContent.DraftState?,
             mediaDraftContentType: EngineChatList.MediaDraftContentType?,
@@ -163,6 +165,7 @@ enum ChatListNodeEntry: Comparable, Identifiable {
             self.messages = messages
             self.readState = readState
             self.nagramIgnoreUnreadBadge = nagramIgnoreUnreadBadge // MARK: NAGRAM
+            self.nagramSuppressActivateInput = nagramSuppressActivateInput // MARK: NAGRAM
             self.isRemovedFromTotalUnreadCount = isRemovedFromTotalUnreadCount
             self.draftState = draftState
             self.mediaDraftContentType = mediaDraftContentType
@@ -200,6 +203,9 @@ enum ChatListNodeEntry: Comparable, Identifiable {
                 return false
             }
             if lhs.nagramIgnoreUnreadBadge != rhs.nagramIgnoreUnreadBadge { // MARK: NAGRAM
+                return false
+            }
+            if lhs.nagramSuppressActivateInput != rhs.nagramSuppressActivateInput { // MARK: NAGRAM
                 return false
             }
             if lhs.messages.count != rhs.messages.count {
@@ -791,8 +797,12 @@ func chatListNodeEntriesForView(view: EngineChatList, state: ChatListNodeState, 
             nagramMessagePeerId = peerId
         }
         let nagramIgnoreUnreadBadge = nagramShouldIgnoreRegexFilteredUnreadBadge(messages: updatedMessages, readState: updatedCombinedReadState, peerId: nagramMessagePeerId, accountPeerId: accountPeerId) // MARK: NAGRAM — 聚合会话按来源会话应用过滤规则
+        // MARK: NAGRAM — hide 规则把预览消息全部过滤掉时，条目会退化成"空会话"，
+        // ChatListItem.selected 会走 peerSelected（该路径恒 activateInput=true）导致进入聊天时误弹键盘。
+        var nagramSuppressActivateInput = false
         if !updatedMessages.isEmpty {
             updatedMessages = nagramFilteredChatListMessages(updatedMessages, peerId: nagramMessagePeerId, accountPeerId: accountPeerId, presentationData: state.presentationData)
+            nagramSuppressActivateInput = updatedMessages.isEmpty // MARK: NAGRAM
         }
 
         var draftState: ChatListItemContent.DraftState?
@@ -838,6 +848,7 @@ func chatListNodeEntriesForView(view: EngineChatList, state: ChatListNodeState, 
             messages: updatedMessages,
             readState: updatedCombinedReadState,
             nagramIgnoreUnreadBadge: nagramIgnoreUnreadBadge,
+            nagramSuppressActivateInput: nagramSuppressActivateInput,
             isRemovedFromTotalUnreadCount: entry.isMuted,
             draftState: draftState,
             mediaDraftContentType: entry.mediaDraftContentType,
@@ -978,6 +989,7 @@ func chatListNodeEntriesForView(view: EngineChatList, state: ChatListNodeState, 
                     let peerId = index.messageIndex.id.peerId
                     let isSelected = state.selectedPeerIds.contains(peerId)
                     let nagramIgnoreUnreadBadge = nagramShouldIgnoreRegexFilteredUnreadBadge(messages: item.item.messages, readState: item.item.readCounters, peerId: peerId, accountPeerId: accountPeerId)
+                    let nagramFilteredMessages = nagramFilteredChatListMessages(item.item.messages, peerId: peerId, accountPeerId: accountPeerId, presentationData: state.presentationData) // MARK: NAGRAM
                     
                     var threadId: Int64 = 0
                     switch item.item.index {
@@ -989,9 +1001,10 @@ func chatListNodeEntriesForView(view: EngineChatList, state: ChatListNodeState, 
                     result.append(.PeerEntry(ChatListNodeEntry.PeerEntryData(
                         index: .chatList(EngineChatList.Item.Index.ChatList(pinningIndex: pinningIndex, messageIndex: index.messageIndex)),
                         presentationData: state.presentationData,
-                        messages: nagramFilteredChatListMessages(item.item.messages, peerId: peerId, accountPeerId: accountPeerId, presentationData: state.presentationData),
+                        messages: nagramFilteredMessages,
                         readState: item.item.readCounters,
                         nagramIgnoreUnreadBadge: nagramIgnoreUnreadBadge,
+                        nagramSuppressActivateInput: !item.item.messages.isEmpty && nagramFilteredMessages.isEmpty, // MARK: NAGRAM
                         isRemovedFromTotalUnreadCount: item.item.isMuted,
                         draftState: draftState,
                         mediaDraftContentType: item.item.mediaDraftContentType,


### PR DESCRIPTION
hide 规则把会话列表唯一的预览消息过滤掉后，条目会退化成「空会话」：
ChatListItem.selected 落到 peerSelected 分支，而该分支恒定传
activateInput = true，最终经 navigateToChatController(activateInput: .text) → ChatController.viewWillAppear 的 scheduledActivateInput → ensureInputViewFocused()，导致点进聊天窗口时系统键盘自动弹出。

改为透传一个抑制标记，保持 messages 为空（列表行不再显示被隐藏
消息的作者名与内容）：

- PeerEntryData / ChatListItemContent.PeerData 新增 nagramSuppressActivateInput，仅在「原本有预览消息、过滤后变空」时置位， 真正的空会话与清空历史仍走原生的自动聚焦逻辑。
- ChatListNodeInteraction 新增 nagramPeerSelectedWithoutActivatingInput， 用 var + 默认 nil 挂载，避免改动其余 ChatListNodeInteraction 构造点。
- ChatListItem.selected 的两个无预览分支短路到该闭包，并补回 upstream 空会话分支丢掉的 threadId，使论坛话题仍进入话题本身。