### PR TITLE
fix:  Respect forceCopyEnabled setting in Gallery

### DIFF
--- a/submodules/GalleryUI/Sources/Items/ChatImageGalleryItem.swift
+++ b/submodules/GalleryUI/Sources/Items/ChatImageGalleryItem.swift
@@ -736,8 +736,8 @@ final class ChatImageGalleryItemNode: ZoomableContentGalleryItemNode {
                     }
                     f(.default)
                 })))
-                
-                if !message.isCopyProtected() && !self.peerIsCopyProtected && message.paidContent == nil, let media = self.contextAndMedia?.1 {
+                // Respect forceCopyEnabled setting
+                if (NagramSettings.shared.forceCopyEnabled || (!message.isCopyProtected() && !self.peerIsCopyProtected)) && message.paidContent == nil, let media = self.contextAndMedia?.1 {
                     items.append(.action(ContextMenuActionItem(text: self.presentationData.strings.Gallery_CreateSticker, icon: { theme in generateTintedImage(image: UIImage(bundleImageName: "Chat/Context Menu/Sticker"), color: theme.actionSheet.primaryTextColor) }, action: { [weak self] _, f in
                         f(.default)
                         guard let self else {

--- a/submodules/GalleryUI/Sources/Items/UniversalVideoGalleryItem.swift
+++ b/submodules/GalleryUI/Sources/Items/UniversalVideoGalleryItem.swift
@@ -3721,7 +3721,8 @@ final class UniversalVideoGalleryItemNode: ZoomableContentGalleryItemNode {
                     }
                 }
             } else {
-                if let (message, maybeFile, _) = strongSelf.contentInfo(), let file = maybeFile, !message.isCopyProtected() && !item.peerIsCopyProtected && message.paidContent == nil {
+                // Respect forceCopyEnabled setting
+                if let (message, maybeFile, _) = strongSelf.contentInfo(), let file = maybeFile, (NagramSettings.shared.forceCopyEnabled || (!message.isCopyProtected() && !item.peerIsCopyProtected)) && message.paidContent == nil {
                     items.append(.action(ContextMenuActionItem(text: strongSelf.presentationData.strings.Gallery_MenuSaveToGallery, icon: { theme in generateTintedImage(image: UIImage(bundleImageName: "Chat/Context Menu/Download"), color: theme.actionSheet.primaryTextColor) }, action: { c, _ in
                         guard let self else {
                             c?.dismiss(result: .default, completion: nil)
@@ -3894,8 +3895,8 @@ final class UniversalVideoGalleryItemNode: ZoomableContentGalleryItemNode {
                         f(.default)
                     })))
                 }
-                
-                if let (message, _, _) = strongSelf.contentInfo(), let image = message.effectiveMedia.first(where: { $0 is TelegramMediaImage }) as? TelegramMediaImage, !message.isCopyProtected() && !item.peerIsCopyProtected && message.paidContent == nil {
+                // Respect forceCopyEnabled setting
+                if let (message, _, _) = strongSelf.contentInfo(), let image = message.effectiveMedia.first(where: { $0 is TelegramMediaImage }) as? TelegramMediaImage, (NagramSettings.shared.forceCopyEnabled || (!message.isCopyProtected() && !item.peerIsCopyProtected)) && message.paidContent == nil {
                     let context = strongSelf.context
                     var videoReference: AnyMediaReference?
                     if let video = image.video {


### PR DESCRIPTION
## Description

Make Gallery respect the `forceCopyEnabled` setting.

Previously, Gallery checked copy protection independently and did not take `forceCopyEnabled` into account, resulting in inconsistent behavior between the message context menu and Gallery.

This PR makes the image and video Gallery respect the existing `forceCopyEnabled` setting for consistent behavior across the app.

Paid content restrictions remain unchanged.