### PR TITLE
Fix crash when opening HTTPS links

### DIFF
--- a/Nagram/SettingsSignal/Sources/NagramSettingsSignal.swift
+++ b/Nagram/SettingsSignal/Sources/NagramSettingsSignal.swift
@@ -82,11 +82,20 @@ public func nagramGlassTransparencySignal() -> Signal<Int32, NoError> {
     let initial = Signal<Int32, NoError>.single(0)
     let changes = Signal<Int32, NoError> { subscriber in
         var version: Int32 = 0
+        var glassTransparencyMode = NagramSettings.shared.glassTransparencyMode
+        var glassTransparencyPercent = NagramSettings.shared.glassTransparencyPercent
         let defaultsObserver = NotificationCenter.default.addObserver(
             forName: UserDefaults.didChangeNotification,
             object: UserDefaults.standard,
             queue: nil
         ) { _ in
+            let updatedMode = NagramSettings.shared.glassTransparencyMode
+            let updatedPercent = NagramSettings.shared.glassTransparencyPercent
+            guard updatedMode != glassTransparencyMode || updatedPercent != glassTransparencyPercent else {
+                return
+            }
+            glassTransparencyMode = updatedMode
+            glassTransparencyPercent = updatedPercent
             version += 1
             subscriber.putNext(version)
         }


### PR DESCRIPTION
## Summary

Prevent an app crash when opening HTTPS links.

`nagramGlassTransparencySignal()` previously emitted for every `UserDefaults.didChangeNotification`, including unrelated defaults changes triggered during `WKWebView` initialization. Each emission refreshed the app theme, which could recursively initialize WebKit and eventually overflow the stack.

The signal now emits only when `glassTransparencyMode` or `glassTransparencyPercent` actually changes.

## Validation

- Built successfully with `release_arm64`
- Verified manually on a physical iPhone
- HTTPS links now open without crashing
- Glass transparency setting updates continue to refresh correctly
